### PR TITLE
skip NugetWindow.OnEnable when entering play mode and changing scripts (assembly reload) to resolve #94

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1208,10 +1208,7 @@
             {
                 if (stopwatch.ElapsedMilliseconds >= 750)
                 {
-                    //LogVerbose("Downloading image timed out! Took more than 750ms.");
-
                     request.Dispose();
-                    stopwatch.Stop();
                     timedout = true;
                     break;
                 }
@@ -1228,6 +1225,11 @@
             {
                 result = request.texture;
             }
+
+            LogVerbose(
+                timedout ? "Downloading image {0} timed out! Took more than 750ms." : "Downloading image {0} took {1} ms",
+                url,
+                stopwatch.ElapsedMilliseconds);
 
             return result;
         }

--- a/Assets/NuGet/Editor/NugetPackage.cs
+++ b/Assets/NuGet/Editor/NugetPackage.cs
@@ -6,47 +6,48 @@
     /// <summary>
     /// Represents a package available from NuGet.
     /// </summary>
+    [Serializable]
     public class NugetPackage : NugetPackageIdentifier, IEquatable<NugetPackage>, IEqualityComparer<NugetPackage>
     {
         /// <summary>
         /// Gets or sets the title (not ID) of the package.  This is the "friendly" name that only appears in GUIs and on webpages.
         /// </summary>
-        public string Title { get; set; }
+        public string Title;
 
         /// <summary>
         /// Gets or sets the description of the NuGet package.
         /// </summary>
-        public string Description { get; set; }
+        public string Description;
 
         /// <summary>
         /// Gets or sets the release notes of the NuGet package.
         /// </summary>
-        public string ReleaseNotes { get; set; }
+        public string ReleaseNotes;
 
         /// <summary>
         /// Gets or sets the URL for the location of the license of the NuGet package.
         /// </summary>
-        public string LicenseUrl { get; set; }
+        public string LicenseUrl;
 
         /// <summary>
         /// Gets or sets the URL for the location of the actual (.nupkg) NuGet package.
         /// </summary>
-        public string DownloadUrl { get; set; }
+        public string DownloadUrl;
 
         /// <summary>
         /// Gets or sets the <see cref="NugetPackageSource"/> that contains this package.
         /// </summary>
-        public NugetPackageSource PackageSource { get; set; }
+        public NugetPackageSource PackageSource;
 
         /// <summary>
         /// Gets or sets the icon for the package as a <see cref="UnityEngine.Texture2D"/>. 
         /// </summary>
-        public UnityEngine.Texture2D Icon { get; set; }
+        public UnityEngine.Texture2D Icon;
 
         /// <summary>
         /// Gets or sets the NuGet packages that this NuGet package depends on.
         /// </summary>
-        public List<NugetPackageIdentifier> Dependencies { get; set; }
+        public List<NugetPackageIdentifier> Dependencies = new List<NugetPackageIdentifier>();
 
         /// <summary>
         /// Checks to see if this <see cref="NugetPackage"/> is equal to the given one.

--- a/Assets/NuGet/Editor/NugetPackageIdentifier.cs
+++ b/Assets/NuGet/Editor/NugetPackageIdentifier.cs
@@ -10,12 +10,12 @@
         /// <summary>
         /// Gets or sets the ID of the NuGet package.
         /// </summary>
-        public string Id { get; set; }
+        public string Id;
 
         /// <summary>
         /// Gets or sets the version number of the NuGet package.
         /// </summary>
-        public string Version { get; set; }
+        public string Version;
 
         /// <summary>
         /// Gets a value indicating whether this is a prerelease package or an official release package.

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -213,7 +214,7 @@
                 filepath += "/MyPackage.nuspec";
             }
 
-            Debug.LogFormat("Creating: {0}", filepath);
+            UnityEngine.Debug.LogFormat("Creating: {0}", filepath);
 
             NuspecFile file = new NuspecFile();
             file.Id = "MyPackage";
@@ -236,6 +237,9 @@
         /// </summary>
         private void OnEnable()
         {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             try
             {
                 // if we are entering playmode, don't do anything
@@ -271,11 +275,13 @@
             }
             catch (Exception e)
             {
-                Debug.LogErrorFormat("{0}", e.ToString());
+                UnityEngine.Debug.LogErrorFormat("{0}", e.ToString());
             }
             finally
             {
                 EditorUtility.ClearProgressBar();
+
+                NugetHelper.LogVerbose("NugetWindow reloading took {0} ms", stopwatch.ElapsedMilliseconds);
             }
         }
 

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -238,6 +238,14 @@
         {
             try
             {
+                // if we are entering playmode, don't do anything
+                if (EditorApplication.isPlayingOrWillChangePlaymode)
+                {
+                    return;
+                }
+
+                NugetHelper.LogVerbose("NugetWindow reloading config and updating packages");
+
                 // reload the NuGet.config file, in case it was changed after Unity opened, but before the manager window opened (now)
                 NugetHelper.LoadNugetConfigFile();
 

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -258,6 +258,9 @@
 
             try
             {
+                // reload the NuGet.config file, in case it was changed after Unity opened, but before the manager window opened (now)
+                NugetHelper.LoadNugetConfigFile();
+
                 // if we are entering playmode, don't do anything
                 if (EditorApplication.isPlayingOrWillChangePlaymode)
                 {
@@ -265,9 +268,6 @@
                 }
 
                 NugetHelper.LogVerbose(hasRefreshed ? "NugetWindow reloading config" : "NugetWindow reloading config and updating packages");
-
-                // reload the NuGet.config file, in case it was changed after Unity opened, but before the manager window opened (now)
-                NugetHelper.LoadNugetConfigFile();
 
                 // set the window title
                 titleContent = new GUIContent("NuGet");


### PR DESCRIPTION
This relates to #94, skipping updates from NuGetWindow.OnEnable when hitting Play.