### PR TITLE
Allows for `repositoryPath` to be any OS's directory separator

### DIFF
--- a/Assets/NuGet/Editor/NugetConfigFile.cs
+++ b/Assets/NuGet/Editor/NugetConfigFile.cs
@@ -207,13 +207,10 @@
 
                         if (!Path.IsPathRooted(configFile.RepositoryPath))
                         {
-                            if (configFile.RepositoryPath.StartsWith("./"))
-                            {
-                                // since ./ is just a relative path to the same directory, replace it
-                                configFile.RepositoryPath = configFile.RepositoryPath.Replace("./", "\\");
-                            }
+                            string repositoryPath = Path.Combine(UnityEngine.Application.dataPath, configFile.RepositoryPath);
+                            repositoryPath = Path.GetFullPath(repositoryPath);
 
-                            configFile.RepositoryPath = Path.GetFullPath((UnityEngine.Application.dataPath + configFile.RepositoryPath).Replace('/', '\\'));
+                            configFile.RepositoryPath = repositoryPath;
                         }
                     }
                     else if (key == "DefaultPushSource")


### PR DESCRIPTION
- ".\" should be just as valid as "./" in the config.
- `Replace` is redundant; GetFullPath converts to the OS's directory path separator.

This should address #102 