### PR TITLE
support environment variables in NuGet.config values

### DIFF
--- a/Assets/NuGet/Editor/NugetConfigFile.cs
+++ b/Assets/NuGet/Editor/NugetConfigFile.cs
@@ -1,5 +1,6 @@
 ﻿namespace NugetForUnity
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -67,7 +68,7 @@
             {
                 addElement = new XElement("add");
                 addElement.Add(new XAttribute("key", source.Name));
-                addElement.Add(new XAttribute("value", source.Path));
+                addElement.Add(new XAttribute("value", source.SavedPath));
                 packageSources.Add(addElement);
 
                 if (!source.IsEnabled)
@@ -84,7 +85,7 @@
                     packageSourceCredentials.Add(sourceElement);
                     addElement = new XElement("add");
                     addElement.Add(new XAttribute("key", "clearTextPassword"));
-                    addElement.Add(new XAttribute("value", source.Password));
+                    addElement.Add(new XAttribute("value", source.SavedPassword));
                     sourceElement.Add(addElement);
                 }
             }
@@ -218,7 +219,7 @@
                             if (add.Attribute("key").Value == "clearTextPassword")
                             {
                                 string password = add.Attribute("value").Value;
-                                source.Password = password;
+                                source.SavedPassword = password;
                             }
                         }
                     }
@@ -238,7 +239,7 @@
                     if (key == "repositoryPath")
                     {
                         configFile.savedRepositoryPath = value;
-                        configFile.RepositoryPath = value;
+                        configFile.RepositoryPath = Environment.ExpandEnvironmentVariables(value);
 
                         if (!Path.IsPathRooted(configFile.RepositoryPath))
                         {

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -161,7 +161,7 @@
             // if there are not command line overrides, use the NuGet.config package sources
             if (!useCommandLineSources)
             {
-                if (NugetConfigFile.ActivePackageSource.Path == "(Aggregate source)")
+                if (NugetConfigFile.ActivePackageSource.ExpandedPath == "(Aggregate source)")
                 {
                     packageSources.AddRange(NugetConfigFile.PackageSources);
                 }
@@ -1043,7 +1043,7 @@
                         LogVerbose("Caching local package {0} {1}", package.Id, package.Version);
 
                         // copy the .nupkg from the local path to the cache
-                        File.Copy(Path.Combine(package.PackageSource.Path, string.Format("./{0}.{1}.nupkg", package.Id, package.Version)), cachedPackagePath, true);
+                        File.Copy(Path.Combine(package.PackageSource.ExpandedPath, string.Format("./{0}.{1}.nupkg", package.Id, package.Version)), cachedPackagePath, true);
                     }
                     else
                     {
@@ -1064,7 +1064,7 @@
                         if (refreshAssets)
                             EditorUtility.DisplayProgressBar(string.Format("Installing {0} {1}", package.Id, package.Version), "Downloading Package", 0.3f);
 
-                        Stream objStream = RequestUrl(package.DownloadUrl, package.PackageSource.Password, timeOut: null);
+                        Stream objStream = RequestUrl(package.DownloadUrl, package.PackageSource.ExpandedPassword, timeOut: null);
                         using (Stream file = File.Create(cachedPackagePath))
                         {
                             CopyStream(objStream, file);

--- a/Assets/NuGet/Editor/NugetPreferences.cs
+++ b/Assets/NuGet/Editor/NugetPreferences.cs
@@ -59,7 +59,7 @@
                         EditorGUILayout.BeginVertical();
                         {
                             source.Name = EditorGUILayout.TextField(source.Name);
-                            source.Path = EditorGUILayout.TextField(source.Path);
+                            source.SavedPath = EditorGUILayout.TextField(source.SavedPath);
                         }
                         EditorGUILayout.EndVertical();
                     }
@@ -73,7 +73,7 @@
                         if (source.HasPassword)
                         {
                             EditorGUIUtility.labelWidth = 0;
-                            source.Password = EditorGUILayout.PasswordField(source.Password);
+                            source.SavedPassword = EditorGUILayout.PasswordField(source.SavedPassword);
                         }
                     }
                     EditorGUILayout.EndHorizontal();


### PR DESCRIPTION
This resolves #97. There are now two versions of these variables:
- Saved: This is the literal version containing the environment variables that is edited and saved into the config file.
- Expanded: This is the version with the environement variables expanded that is used to perform the actual NuGet operations.