### PR TITLE
Install via the identifier to fix VSTS

### DIFF
--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -814,7 +814,7 @@
                     {
                         if (GUILayout.Button("Install", installButtonWidth))
                         {
-                            NugetHelper.Install(package);
+                            NugetHelper.InstallIdentifier(package);
                             AssetDatabase.Refresh();
                             UpdateInstalledPackages();
                             UpdateUpdatePackages();


### PR DESCRIPTION
VSTS doesn't include dependencies on multipackage queries. By installing
by package id we query explicitly for this single package and thus get
the dependencies. This works for nuget.org as well.

Resolve #107 