### PR TITLE
Improve VSTS nuget feed support

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1169,7 +1169,7 @@
                 getRequest.ReadWriteTimeout = timeOut.Value;
             }
 
-            if (packageHost.EndsWith("pkgs.visualstudio.com") && password == null)
+            if (packageHost.EndsWith("pkgs.visualstudio.com") && string.IsNullOrEmpty(password))
             {
                 // The host is a VisualStudio feed (which requires authentication) but a password was not provided. Use the VSS credential provider to aquire a token and append
                 // it to the request.

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1315,6 +1315,12 @@
             public string Password;
         }
 
+        /// <summary>
+        /// Helper function to aquire a token to access VSTS hosted nuget feeds by using the CredentialProvider.VSS.exe
+        /// tool. Downloading it from the VSTS instance if needed.
+        /// </summary>
+        /// <param name="packageHost">The hostname where the VSTS instance is hosted (such as microsoft.pkgs.visualsudio.com</param>
+        /// <returns>The password in the form of a token, or null if the password could not be aquired</returns>
         private static string GetPasswordFromVSTSCredentialProvider(string packageHost)
         {
             string credentialProviderBundleFilename = "CredentialProviderBundle.zip";

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1341,8 +1341,14 @@
             // Build the list of possible locations to find the credential provider. In order it should be local app data, paths set on the
             // environment varaible, and lastly look at the root of the pacakges save location.
             List<string> possibleCredentialProviderPaths = new List<string>();
-            possibleCredentialProviderPaths.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Nuget", "CredentialProviders"));
-            possibleCredentialProviderPaths.AddRange(Environment.GetEnvironmentVariable("NUGET_CREDENTIALPROVIDERS_PATH")?.Split(';') ?? new string[]{});
+            possibleCredentialProviderPaths.Add(Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Nuget"), "CredentialProviders"));
+
+            string environmentCredentialProviderPaths = Environment.GetEnvironmentVariable("NUGET_CREDENTIALPROVIDERS_PATH");
+            if (!String.IsNullOrEmpty(environmentCredentialProviderPaths))
+            {
+                possibleCredentialProviderPaths.AddRange(environmentCredentialProviderPaths.Split(';') ?? new string[] {});
+            }
+
             possibleCredentialProviderPaths.Add(NugetConfigFile.RepositoryPath);
 
             // Search through all possible paths to find the credential provider.

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1310,11 +1310,9 @@
         [System.Serializable]
         private struct VSSCredentialResponse
         {
-#pragma warning disable 0649
             public string __VssPasswordWarning;
             public string Username;
             public string Password;
-#pragma warning restore 0649
         }
 
         private static string GetPasswordFromVSTSCredentialProvider(string packageHost)


### PR DESCRIPTION
Visual Studio Team Services hosted projects have built in support for hosting nuget feeds, but authenticating with them is a bit cumbersome. NuGetForUnity currently supports connecting to the feed by generating a personal access token (PAT) and passing that in using basic HTTP authentication. Howerver that requires each user to go out of their way to generate a PAT and get it piped into NuGetForUnity.


This change adds support for using CredentialProvider.VSS.exe to obtain the authentication token rather than requiring the user to generate it (see [here](https://docs.microsoft.com/en-us/vsts/package/nuget/nuget-exe?view=vsts#download-the-credential-provider-directly) for more info on the credential provider). The first time the user connects to a VSTS feed they will get a prompt to enter their VSTS credentials (through the CredentialProvider.VSS.exe). Subsequent connections after that will be silent as the credential provider handles caching the token as well.