### PR TITLE
Added support for "ignored" dependencies in config file

### DIFF
--- a/Assets/NuGet/Editor/NugetConfigFile.cs
+++ b/Assets/NuGet/Editor/NugetConfigFile.cs
@@ -50,6 +50,12 @@
         public bool ReadOnlyPackageFiles { get; set; }
 
         /// <summary>
+        /// Package IDs of dependancies to ignore.
+        /// ie, ones to not install;
+        /// </summary>
+        public HashSet<string> IgnoredDependencies { get; set; }
+
+        /// <summary>
         /// The incomplete path that is saved.  The path is expanded and made public via the property above.
         /// </summary>
         private string savedRepositoryPath;
@@ -159,6 +165,17 @@
                     attributes &= ~FileAttributes.ReadOnly;
                     File.SetAttributes(filepath, attributes);
                 }
+            }
+
+            // saving ignored dependencies
+
+            XElement ignoredDependencies = new XElement("ignoredDependencies");
+
+            foreach (var iDependancyPackageID in IgnoredDependencies)
+            {
+                addElement = new XElement("add");
+                addElement.Add(new XAttribute("value", iDependancyPackageID));
+                ignoredDependencies.Add(addElement);
             }
 
             configFile.Save(filepath);
@@ -282,6 +299,17 @@
                 }
             }
 
+            // loading ignored dependencies
+            configFile.IgnoredDependencies = new HashSet<string>();
+            XElement ignoredDependencies = file.Root.Element("ignoredDependencies");
+            if (config != null)
+            {
+                foreach (var iIgnoredDepencency in ignoredDependencies.Elements("add"))
+                {
+                    configFile.IgnoredDependencies.Add(iIgnoredDepencency.Attribute("value").Value);
+                }
+            }
+
             return configFile;
         }
 
@@ -292,7 +320,7 @@
         /// <returns>The loaded <see cref="NugetConfigFile"/> loaded off of the newly created default file.</returns>
         public static NugetConfigFile CreateDefaultFile(string filePath)
         {
-            const string contents =
+            string contents =
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
@@ -306,11 +334,166 @@
        <add key=""repositoryPath"" value=""./Packages"" />
        <add key=""DefaultPushSource"" value=""http://www.nuget.org/api/v2/"" />
     </config>
+";
+
+            // add ignored
+
+            contents +=
+@"    <ignoredDependencies>" + "\n";
+
+            foreach (var iPackageID in dependenciesUnityGet())
+            {
+                contents += string.Format(
+@"       <add value=""{0}"" />" + "\n", iPackageID
+                );
+            }
+
+            contents +=
+@"    </ignoredDependencies>
 </configuration>";
 
             File.WriteAllText(filePath, contents, new UTF8Encoding());
 
             return Load(filePath);
+        }
+
+        /// <summary>
+        /// Get all the dependencies that are referenced in Unity assemblies by default;
+        /// </summary>
+        private static IEnumerable<string> dependenciesUnityGet()
+        {
+            return new HashSet<string>(){
+                // Unity 2018.1.1f1, Assembly-CSharp OR Assembly-CSharp-Editor
+                // engine assemblies have these added to them by default
+
+                "Microsoft.Win32.Primitives",
+                "mscorlib",
+                "netstandard",
+                "System",
+                "System.AppContext",
+                "System.Collections",
+                "System.Collections.Concurrent",
+                "System.Collections.NonGeneric",
+                "System.Collections.Specialized",
+                "System.ComponentModel",
+                "System.ComponentModel.Composition",
+                "System.ComponentModel.EventBasedAsync",
+                "System.ComponentModel.Primitives",
+                "System.ComponentModel.TypeConverter",
+                "System.Console",
+                "System.Core",
+                "System.Data",
+                "System.Data.Common",
+                "System.Diagnostics.Contracts",
+                "System.Diagnostics.Debug",
+                "System.Diagnostics.FileVersionInfo",
+                "System.Diagnostics.Process",
+                "System.Diagnostics.StackTrace",
+                "System.Diagnostics.TextWriterTraceListener",
+                "System.Diagnostics.Tools",
+                "System.Diagnostics.TraceSource",
+                "System.Diagnostics.Tracing",
+                "System.Drawing",
+                "System.Drawing.Primitives",
+                "System.Dynamic.Runtime",
+                "System.Globalization",
+                "System.Globalization.Calendars",
+                "System.Globalization.Extensions",
+                "System.IO",
+                "System.IO.Compression",
+                "System.IO.Compression.FileSystem",
+                "System.IO.Compression.ZipFile",
+                "System.IO.FileSystem",
+                "System.IO.FileSystem.DriveInfo",
+                "System.IO.FileSystem.Primitives",
+                "System.IO.FileSystem.Watcher",
+                "System.IO.IsolatedStorage",
+                "System.IO.MemoryMappedFiles",
+                "System.IO.Pipes",
+                "System.IO.UnmanagedMemoryStream",
+                "System.Linq",
+                "System.Linq.Expressions",
+                "System.Linq.Parallel",
+                "System.Linq.Queryable",
+                "System.Net",
+                "System.Net.Http",
+                "System.Net.NameResolution",
+                "System.Net.NetworkInformation",
+                "System.Net.Ping",
+                "System.Net.Primitives",
+                "System.Net.Requests",
+                "System.Net.Security",
+                "System.Net.Sockets",
+                "System.Net.WebHeaderCollection",
+                "System.Net.WebSockets",
+                "System.Net.WebSockets.Client",
+                "System.Numerics",
+                "System.ObjectModel",
+                "System.Reflection",
+                "System.Reflection.Extensions",
+                "System.Reflection.Primitives",
+                "System.Resources.Reader",
+                "System.Resources.ResourceManager",
+                "System.Resources.Writer",
+                "System.Runtime",
+                "System.Runtime.CompilerServices.VisualC",
+                "System.Runtime.Extensions",
+                "System.Runtime.Handles",
+                "System.Runtime.InteropServices",
+                "System.Runtime.InteropServices.RuntimeInformation",
+                "System.Runtime.Numerics",
+                "System.Runtime.Serialization",
+                "System.Runtime.Serialization.Formatters",
+                "System.Runtime.Serialization.Json",
+                "System.Runtime.Serialization.Primitives",
+                "System.Runtime.Serialization.Xml",
+                "System.Security.Claims",
+                "System.Security.Cryptography.Algorithms",
+                "System.Security.Cryptography.Csp",
+                "System.Security.Cryptography.Encoding",
+                "System.Security.Cryptography.Primitives",
+                "System.Security.Cryptography.X509Certificates",
+                "System.Security.Principal",
+                "System.Security.SecureString",
+                "System.ServiceModel.Web",
+                "System.Text.Encoding",
+                "System.Text.Encoding.Extensions",
+                "System.Text.RegularExpressions",
+                "System.Threading",
+                "System.Threading.Overlapped",
+                "System.Threading.Tasks",
+                "System.Threading.Tasks.Parallel",
+                "System.Threading.Thread",
+                "System.Threading.ThreadPool",
+                "System.Threading.Timer",
+                "System.Transactions",
+                "System.ValueTuple",
+                "System.Web",
+                "System.Windows",
+                "System.Xml",
+                "System.Xml.Linq",
+                "System.Xml.ReaderWriter",
+                "System.Xml.Serialization",
+                "System.Xml.XDocument",
+                "System.Xml.XmlDocument",
+                "System.Xml.XmlSerializer",
+                "System.Xml.XPath",
+                "System.Xml.XPath.XDocument",
+                
+                // Unity 2018.1.1f1, ONLY Assembly-CSharp-Editor
+                // editor assemblies have these added to them by default
+
+                "System.Net.Http.Rtc",
+                "System.Reflection.Emit",
+                "System.Reflection.Emit.ILGeneration",
+                "System.Reflection.Emit.Lightweight",
+                "System.Runtime.InteropServices.WindowsRuntime",
+                "System.ServiceModel.Duplex",
+                "System.ServiceModel.Http",
+                "System.ServiceModel.NetTcp",
+                "System.ServiceModel.Primitives",
+                "System.ServiceModel.Security",
+            };
         }
     }
 }

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1073,8 +1073,15 @@
                 // install all dependencies
                 foreach (var dependency in package.Dependencies)
                 {
-                    LogVerbose("Installing Dependency: {0} {1}", dependency.Id, dependency.Version);
-                    InstallIdentifier(dependency);
+                    if (!ignoreDependancyShould(dependency.Id)) // it not an ignored dependancy
+                    {
+                        LogVerbose("Installing Dependency: {0} {1}", dependency.Id, dependency.Version);
+                        InstallIdentifier(dependency);
+                    }
+                    else
+                    {
+                        LogVerbose("Ignoring Dependency: {0} {1}", dependency.Id, dependency.Version);
+                    }
                 }
 
                 // update packages.config
@@ -1330,5 +1337,11 @@
 
             return result;
         }
+
+        /// <summary>
+        /// Should ignore a dependancy?;
+        /// </summary>
+        static private bool ignoreDependancyShould(string packageID)
+        => NugetConfigFile.IgnoredDependencies.Contains(packageID);
     }
 }


### PR DESCRIPTION
A quick fix for Issue #171.

Ideally, ignored packages should be linked to the engine or editor. After installing, the "platform settings" should be programmatically changed to exclude that platform. This is because assemblies compiled for the engine and editor platforms have different default references.

ie, if a "plugin" included by default in engine platform, its "platform settings" should exclude the engine platform.