### PR TITLE
Deleting unnecessary folders after update packages.config from git.

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1267,6 +1267,8 @@
 
                     currentProgress += progressStep;
                 }
+
+                CheckForUnnecessaryPackages();
             }
             catch (Exception e)
             {
@@ -1280,6 +1282,28 @@
                 AssetDatabase.Refresh();
                 EditorUtility.ClearProgressBar();
             }
+        }
+
+        internal static void CheckForUnnecessaryPackages() {
+            var directories = Directory.GetDirectories(NugetConfigFile.RepositoryPath, "*", SearchOption.TopDirectoryOnly);
+            foreach (var folder in directories) {
+                var name = Path.GetFileName(folder);
+                var installed = false;
+                foreach (var package in PackagesConfigFile.Packages) {
+                    var packageName = string.Format("{0}.{1}", package.Id, package.Version);
+                    if (name == packageName) {
+                        installed = true;
+                        break;
+                    }
+                }
+                if (!installed) {
+                    LogVerbose("---DELETE unnecessary package {0}", name);
+
+                    DeleteDirectory(folder);
+                    DeleteFile(folder + ".meta");
+                }
+            }
+
         }
 
         /// <summary>

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -11,6 +11,7 @@
     using UnityEditor;
     using UnityEngine;
     using Debug = UnityEngine.Debug;
+    using System.Security.Cryptography;
 
     /// <summary>
     /// A set of helper methods that act as a wrapper around nuget.exe
@@ -1335,6 +1336,12 @@
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
+            bool fromCache = false;
+            if (ExistsInDiskCache(url)) {
+                url = "file:///" + GetFilePath(url);
+                fromCache = true;
+            }
+
             WWW request = new WWW(url);
             while (!request.isDone)
             {
@@ -1346,24 +1353,52 @@
                 }
             }
 
-            if (!timedout && !string.IsNullOrEmpty(request.error))
-            {
-                LogVerbose(request.error);
-            }
-
             Texture2D result = null;
 
-            if (!timedout && string.IsNullOrEmpty(request.error))
-            {
-                result = request.texture;
+            if (timedout) {
+                LogVerbose("Downloading image {0} timed out! Took more than 750ms.", url);
+            }
+            else {
+                if (string.IsNullOrEmpty(request.error)) {
+                    result = request.textureNonReadable;
+                    LogVerbose("Downloading image {0} took {1} ms", url, stopwatch.ElapsedMilliseconds);
+                }
+                else
+                    LogVerbose("Request error: " + request.error);
             }
 
-            LogVerbose(
-                timedout ? "Downloading image {0} timed out! Took more than 750ms." : "Downloading image {0} took {1} ms",
-                url,
-                stopwatch.ElapsedMilliseconds);
+           
+            if (result != null && !fromCache) {
+                CacheTextureOnDisk(url, request.bytes);
+            }
 
+            request.Dispose();
             return result;
+        }
+
+        private static void CacheTextureOnDisk(string url, byte[] bytes) {
+            string diskPath = GetFilePath(url);
+            File.WriteAllBytes(diskPath, bytes);
+        }
+
+        private static bool ExistsInDiskCache(string url) {
+            return File.Exists(GetFilePath(url));
+        }
+
+        private static string GetFilePath(string url) {
+            return Path.Combine(Application.temporaryCachePath, GetHash(url));
+        }
+
+        private static string GetHash(string s) {
+            if (string.IsNullOrEmpty(s))
+                return null;
+            MD5CryptoServiceProvider md5 = new MD5CryptoServiceProvider();
+            byte[] data = md5.ComputeHash(Encoding.Default.GetBytes(s));
+            StringBuilder sBuilder = new StringBuilder();
+            for (int i = 0; i < data.Length; i++) {
+                sBuilder.Append(data[i].ToString("x2"));
+            }
+            return sBuilder.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
Description of the problem that is solved:
When one developer uninstall any package and commit it. The folder remove on this developer pc, but other developer pull this changes, Assets/Packages folder in ignore, open Unity and automatically start restore packages. Folder still exist because there is no code for check this.