### PR TITLE
fix #201 by removing installed packages list cached in NugetWindow

### DIFF
--- a/Assets/NuGet/Editor/DependencyTreeViewer.cs
+++ b/Assets/NuGet/Editor/DependencyTreeViewer.cs
@@ -68,7 +68,7 @@
                 EditorUtility.DisplayProgressBar("Building Dependency Tree", "Reading installed packages...", 0.5f);
 
                 NugetHelper.UpdateInstalledPackages();
-                installedPackages = NugetHelper.GetInstalledPackages().Values.ToList();
+                installedPackages = NugetHelper.InstalledPackages.ToList();
                 List<string> installedPackageNames = new List<string>();
 
                 foreach (NugetPackage package in installedPackages)

--- a/Assets/NuGet/Editor/DependencyTreeViewer.cs
+++ b/Assets/NuGet/Editor/DependencyTreeViewer.cs
@@ -67,6 +67,7 @@
 
                 EditorUtility.DisplayProgressBar("Building Dependency Tree", "Reading installed packages...", 0.5f);
 
+                NugetHelper.UpdateInstalledPackages();
                 installedPackages = NugetHelper.GetInstalledPackages().Values.ToList();
                 List<string> installedPackageNames = new List<string>();
 

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -729,7 +729,7 @@
         /// </summary>
         /// <param name="updates">The list of all updates to install.</param>
         /// <param name="packagesToUpdate">The list of all packages currently installed.</param>
-        public static void UpdateAll(IEnumerable<NugetPackage> updates, List<NugetPackage> packagesToUpdate)
+        public static void UpdateAll(IEnumerable<NugetPackage> updates, IEnumerable<NugetPackage> packagesToUpdate)
         {
             float progressStep = 1.0f / updates.Count();
             float currentProgress = 0;
@@ -851,7 +851,7 @@
         /// <param name="targetFrameworks">The specific frameworks to target?</param>
         /// <param name="versionContraints">The version constraints?</param>
         /// <returns>A list of all updates available.</returns>
-        public static List<NugetPackage> GetUpdates(List<NugetPackage> packagesToUpdate, bool includePrerelease = false, bool includeAllVersions = false, string targetFrameworks = "", string versionContraints = "")
+        public static List<NugetPackage> GetUpdates(IEnumerable<NugetPackage> packagesToUpdate, bool includePrerelease = false, bool includeAllVersions = false, string targetFrameworks = "", string versionContraints = "")
         {
             List<NugetPackage> packages = new List<NugetPackage>();
 

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -760,10 +760,7 @@
         /// Gets the dictionary of packages that are actually installed in the project, keyed off of the ID.
         /// </summary>
         /// <returns>A dictionary of installed <see cref="NugetPackage"/>s.</returns>
-        public static Dictionary<string, NugetPackage> GetInstalledPackages()
-        {
-            return installedPackages;
-        }
+        public static IEnumerable<NugetPackage> InstalledPackages { get { return installedPackages.Values; } }
 
         /// <summary>
         /// Updates the dictionary of packages that are actually installed in the project based on the files that are currently installed.

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -762,6 +762,14 @@
         /// <returns>A dictionary of installed <see cref="NugetPackage"/>s.</returns>
         public static Dictionary<string, NugetPackage> GetInstalledPackages()
         {
+            return installedPackages;
+        }
+
+        /// <summary>
+        /// Updates the dictionary of packages that are actually installed in the project based on the files that are currently installed.
+        /// </summary>
+        public static void UpdateInstalledPackages()
+        {
             LoadNugetConfigFile();
 
             Stopwatch stopwatch = new Stopwatch();
@@ -805,8 +813,6 @@
 
             stopwatch.Stop();
             LogVerbose("Getting installed packages took {0} ms", stopwatch.ElapsedMilliseconds);
-
-            return installedPackages;
         }
 
         /// <summary>
@@ -1234,7 +1240,7 @@
         /// </summary>
         public static void Restore()
         {
-            GetInstalledPackages();
+            UpdateInstalledPackages();
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -32,19 +32,6 @@
         [SerializeField]
         private List<NugetPackage> availablePackages = new List<NugetPackage>();
 
-        private IEnumerable<NugetPackage> InstalledPackages { get { return NugetHelper.GetInstalledPackages().Values; } }
-
-        private IEnumerable<NugetPackage> FilteredInstalledPackages
-        {
-            get
-            {
-                if (installedSearchTerm == "Search")
-                    return InstalledPackages;
-
-                return InstalledPackages.Where(x => x.Id.ToLower().Contains(installedSearchTerm) || x.Title.ToLower().Contains(installedSearchTerm)).ToList();
-            }
-        }
-
         /// <summary>
         /// The list of package updates available, based on the already installed packages.
         /// </summary>
@@ -139,6 +126,19 @@
         /// Used to keep track of which packages the user has opened the clone window on.
         /// </summary>
         private HashSet<NugetPackage> openCloneWindows = new HashSet<NugetPackage>();
+
+        private IEnumerable<NugetPackage> InstalledPackages { get { return NugetHelper.GetInstalledPackages().Values; } }
+
+        private IEnumerable<NugetPackage> FilteredInstalledPackages
+        {
+            get
+            {
+                if (installedSearchTerm == "Search")
+                    return InstalledPackages;
+
+                return InstalledPackages.Where(x => x.Id.ToLower().Contains(installedSearchTerm) || x.Title.ToLower().Contains(installedSearchTerm)).ToList();
+            }
+        }
 
         /// <summary>
         /// Opens the NuGet Package Manager Window.
@@ -350,7 +350,7 @@
                     UpdateOnlinePackages();
 
                     EditorUtility.DisplayProgressBar("Opening NuGet", "Getting installed packages...", 0.6f);
-                    UpdateInstalledPackages();
+                    NugetHelper.UpdateInstalledPackages();
 
                     EditorUtility.DisplayProgressBar("Opening NuGet", "Getting available updates...", 0.9f);
                     UpdateUpdatePackages();
@@ -379,15 +379,6 @@
         private void UpdateOnlinePackages()
         {
             availablePackages = NugetHelper.Search(onlineSearchTerm != "Search" ? onlineSearchTerm : string.Empty, showAllOnlineVersions, showOnlinePrerelease, numberToGet, numberToSkip);
-        }
-
-        /// <summary>
-        /// Updates the list of installed packages.
-        /// </summary>
-        private void UpdateInstalledPackages()
-        {
-            // load a list of install packages
-            NugetHelper.UpdateInstalledPackages();
         }
 
         /// <summary>
@@ -739,7 +730,7 @@
                     if (GUILayout.Button("Install All Updates", GUILayout.Width(150)))
                     {
                         NugetHelper.UpdateAll(updatePackages, InstalledPackages);
-                        UpdateInstalledPackages();
+                        NugetHelper.UpdateInstalledPackages();
                         UpdateUpdatePackages();
                     }
                 }
@@ -838,7 +829,7 @@
                     {
                         // TODO: Perhaps use a "mark as dirty" system instead of updating all of the data all the time? 
                         NugetHelper.Uninstall(package);
-                        UpdateInstalledPackages();
+                        NugetHelper.UpdateInstalledPackages();
                         UpdateUpdatePackages();
                     }
                 }
@@ -852,7 +843,7 @@
                             if (GUILayout.Button(string.Format("Update to [{0}]", package.Version), installButtonWidth, installButtonHeight))
                             {
                                 NugetHelper.Update(installed, package);
-                                UpdateInstalledPackages();
+                                NugetHelper.UpdateInstalledPackages();
                                 UpdateUpdatePackages();
                             }
                         }
@@ -862,7 +853,7 @@
                             if (GUILayout.Button(string.Format("Downgrade to [{0}]", package.Version), installButtonWidth, installButtonHeight))
                             {
                                 NugetHelper.Update(installed, package);
-                                UpdateInstalledPackages();
+                                NugetHelper.UpdateInstalledPackages();
                                 UpdateUpdatePackages();
                             }
                         }
@@ -873,7 +864,7 @@
                         {
                             NugetHelper.InstallIdentifier(package);
                             AssetDatabase.Refresh();
-                            UpdateInstalledPackages();
+                            NugetHelper.UpdateInstalledPackages();
                             UpdateUpdatePackages();
                         }
                     }

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -32,11 +32,7 @@
         [SerializeField]
         private List<NugetPackage> availablePackages = new List<NugetPackage>();
 
-        /// <summary>
-        /// The list of NugetPackages already installed.
-        /// </summary>
-        [SerializeField]
-        private List<NugetPackage> installedPackages = new List<NugetPackage>();
+        private static IEnumerable<NugetPackage> InstalledPackages { get { return NugetHelper.GetInstalledPackages().Values; } }
 
         /// <summary>
         /// The filtered list of NugetPackages already installed.
@@ -379,12 +375,11 @@
         {
             // load a list of install packages
             NugetHelper.UpdateInstalledPackages();
-            installedPackages = NugetHelper.GetInstalledPackages().Values.ToList();
-            filteredInstalledPackages = installedPackages;
+            filteredInstalledPackages = InstalledPackages.ToList();
 
             if (installedSearchTerm != "Search")
             {
-                filteredInstalledPackages = installedPackages.Where(x => x.Id.ToLower().Contains(installedSearchTerm) || x.Title.ToLower().Contains(installedSearchTerm)).ToList();
+                filteredInstalledPackages = filteredInstalledPackages.Where(x => x.Id.ToLower().Contains(installedSearchTerm) || x.Title.ToLower().Contains(installedSearchTerm)).ToList();
             }
         }
 
@@ -394,7 +389,7 @@
         private void UpdateUpdatePackages()
         {
             // get any available updates for the installed packages
-            updatePackages = NugetHelper.GetUpdates(installedPackages, showPrereleaseUpdates, showAllUpdateVersions);
+            updatePackages = NugetHelper.GetUpdates(InstalledPackages, showPrereleaseUpdates, showAllUpdateVersions);
             filteredUpdatePackages = updatePackages;
 
             if (updatesSearchTerm != "Search")
@@ -703,7 +698,7 @@
                 {
                     if (installedSearchTerm != "Search")
                     {
-                        filteredInstalledPackages = installedPackages.Where(x => x.Id.ToLower().Contains(installedSearchTerm) || x.Title.ToLower().Contains(installedSearchTerm)).ToList();
+                        filteredInstalledPackages = InstalledPackages.Where(x => x.Id.ToLower().Contains(installedSearchTerm) || x.Title.ToLower().Contains(installedSearchTerm)).ToList();
                     }
                 }
             }
@@ -738,7 +733,7 @@
 
                     if (GUILayout.Button("Install All Updates", GUILayout.Width(150)))
                     {
-                        NugetHelper.UpdateAll(updatePackages, installedPackages);
+                        NugetHelper.UpdateAll(updatePackages, InstalledPackages);
                         UpdateInstalledPackages();
                         UpdateUpdatePackages();
                     }
@@ -788,6 +783,7 @@
         /// <param name="package">The <see cref="NugetPackage"/> to draw.</param>
         private void DrawPackage(NugetPackage package, GUIStyle packageStyle, GUIStyle contrastStyle)
         {
+            IEnumerable<NugetPackage> installedPackages = InstalledPackages;
             var installed = installedPackages.FirstOrDefault(p => p.Id == package.Id);
 
             EditorGUILayout.BeginHorizontal();

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -378,6 +378,7 @@
         private void UpdateInstalledPackages()
         {
             // load a list of install packages
+            NugetHelper.UpdateInstalledPackages();
             installedPackages = NugetHelper.GetInstalledPackages().Values.ToList();
             filteredInstalledPackages = installedPackages;
 

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -127,16 +127,14 @@
         /// </summary>
         private HashSet<NugetPackage> openCloneWindows = new HashSet<NugetPackage>();
 
-        private IEnumerable<NugetPackage> InstalledPackages { get { return NugetHelper.GetInstalledPackages().Values; } }
-
         private IEnumerable<NugetPackage> FilteredInstalledPackages
         {
             get
             {
                 if (installedSearchTerm == "Search")
-                    return InstalledPackages;
+                    return NugetHelper.InstalledPackages;
 
-                return InstalledPackages.Where(x => x.Id.ToLower().Contains(installedSearchTerm) || x.Title.ToLower().Contains(installedSearchTerm)).ToList();
+                return NugetHelper.InstalledPackages.Where(x => x.Id.ToLower().Contains(installedSearchTerm) || x.Title.ToLower().Contains(installedSearchTerm)).ToList();
             }
         }
 
@@ -387,7 +385,7 @@
         private void UpdateUpdatePackages()
         {
             // get any available updates for the installed packages
-            updatePackages = NugetHelper.GetUpdates(InstalledPackages, showPrereleaseUpdates, showAllUpdateVersions);
+            updatePackages = NugetHelper.GetUpdates(NugetHelper.InstalledPackages, showPrereleaseUpdates, showAllUpdateVersions);
             filteredUpdatePackages = updatePackages;
 
             if (updatesSearchTerm != "Search")
@@ -729,7 +727,7 @@
 
                     if (GUILayout.Button("Install All Updates", GUILayout.Width(150)))
                     {
-                        NugetHelper.UpdateAll(updatePackages, InstalledPackages);
+                        NugetHelper.UpdateAll(updatePackages, NugetHelper.InstalledPackages);
                         NugetHelper.UpdateInstalledPackages();
                         UpdateUpdatePackages();
                     }
@@ -779,7 +777,7 @@
         /// <param name="package">The <see cref="NugetPackage"/> to draw.</param>
         private void DrawPackage(NugetPackage package, GUIStyle packageStyle, GUIStyle contrastStyle)
         {
-            IEnumerable<NugetPackage> installedPackages = InstalledPackages;
+            IEnumerable<NugetPackage> installedPackages = NugetHelper.InstalledPackages;
             var installed = installedPackages.FirstOrDefault(p => p.Id == package.Id);
 
             EditorGUILayout.BeginHorizontal();

--- a/Assets/NuGet/Editor/NuspecEditor.cs
+++ b/Assets/NuGet/Editor/NuspecEditor.cs
@@ -198,6 +198,7 @@
                         // automatically fill in the dependencies based upon the "root" packages currently installed in the project
                         if (GUILayout.Button(new GUIContent("Automatically Fill Dependencies", "Populates the list of dependencies with the \"root\" NuGet packages currently installed in the project.")))
                         {
+                            NugetHelper.UpdateInstalledPackages();
                             List<NugetPackage> installedPackages = NugetHelper.GetInstalledPackages().Values.ToList();
 
                             // default all packages to being roots

--- a/Assets/NuGet/Editor/NuspecEditor.cs
+++ b/Assets/NuGet/Editor/NuspecEditor.cs
@@ -199,7 +199,7 @@
                         if (GUILayout.Button(new GUIContent("Automatically Fill Dependencies", "Populates the list of dependencies with the \"root\" NuGet packages currently installed in the project.")))
                         {
                             NugetHelper.UpdateInstalledPackages();
-                            List<NugetPackage> installedPackages = NugetHelper.GetInstalledPackages().Values.ToList();
+                            List<NugetPackage> installedPackages = NugetHelper.InstalledPackages.ToList();
 
                             // default all packages to being roots
                             List<NugetPackage> roots = new List<NugetPackage>(installedPackages);


### PR DESCRIPTION
In investigating #201, I found that a package could be saved as installed after it has been removed by NugetHelper.CheckForUnnecessaryPackages. This can be fixed, and the overall code can be simplified, by removing the NugetWindow.installedPackages list that was being cached and, instead, directly using the list of installed packages that NugetHelper maintains.