### PR TITLE
Fix for a string formatting exception during package installation

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -977,7 +977,7 @@
 
                 if (foundPackage.Version == packageId.Version)
                 {
-                    LogVerbose("{0} {1} was found in {2}", foundPackage.Id, foundPackage.Version);
+                    LogVerbose("{0} {1} was found in {2}", foundPackage.Id, foundPackage.Version, source.Name);
                     return foundPackage;
                 }
 


### PR DESCRIPTION
There was a missing format arg. The string expects three formatting args, but only two were provided.

The resulting exception appears to prevent new packages from being installed.