### PR TITLE
Revert "Merge pull request #155 from OriginalSINe/feature/dependancie…

### DIFF
--- a/Assets/NuGet/Editor/NuspecFile.cs
+++ b/Assets/NuGet/Editor/NuspecFile.cs
@@ -114,28 +114,6 @@
         public List<NuspecContentFile> Files { get; set; }
 
         /// <summary>
-        /// Add a "dependancy" node;
-        /// </summary>
-        private void addDependancy(XElement dependencyElement)
-        {
-            NugetPackageIdentifier dependency = new NugetPackageIdentifier();
-            dependency.Id = (string)dependencyElement.Attribute("id") ?? string.Empty;
-            dependency.Version = (string)dependencyElement.Attribute("version") ?? string.Empty;
-            Dependencies.Add(dependency);
-        }
-
-        /// <summary>
-        /// Add all the "dependancy" nodes under <paramref name="dependenciesElement"/>;
-        /// </summary>
-        private void addDependancies(XElement dependenciesElement, string nuspecNamespace)
-        {
-            foreach (var dependencyElement in dependenciesElement.Elements(XName.Get("dependency", nuspecNamespace)))
-            {
-                addDependancy(dependencyElement);
-            }
-        }
-
-        /// <summary>
         /// Loads the .nuspec file inside the .nupkg file at the given filepath.
         /// </summary>
         /// <param name="nupkgFilepath">The filepath to the .nupkg file to load.</param>
@@ -237,17 +215,12 @@
             var dependenciesElement = metadata.Element(XName.Get("dependencies", nuspecNamespace));
             if (dependenciesElement != null)
             {
-                IEnumerable<XElement> groups = dependenciesElement.Elements(XName.Get("group", nuspecNamespace)); // get groups
-                if (groups.Count() > 0) // if there are groups
+                foreach (var dependencyElement in dependenciesElement.Elements(XName.Get("dependency", nuspecNamespace)))
                 {
-                    foreach (var iGroup in groups) // add dependancy in game
-                    {
-                    nuspec.addDependancies(iGroup, nuspecNamespace);
-                    }
-                }
-                else // no groups; add children of "dependancies"
-                {
-                    nuspec.addDependancies(dependenciesElement, nuspecNamespace);
+                    NugetPackageIdentifier dependency = new NugetPackageIdentifier();
+                    dependency.Id = (string)dependencyElement.Attribute("id") ?? string.Empty;
+                    dependency.Version = (string)dependencyElement.Attribute("version") ?? string.Empty;
+                    nuspec.Dependencies.Add(dependency);
                 }
             }
 


### PR DESCRIPTION
…sGroups"

This reverts commit d9b2f22cdec8316f4f956118eeab21d74dbd99b6, reversing
changes made to 26e6cd53aca396d7f22cbb9d8a9f4798c5ea96b1.

This was breaking previously successful behavior for key packages. I'm in the middle of adding full support for target framework specifications in packages config and full dependency group support. As that'll take into January I want to unblock the recent breakage with this hot fix.