### PR TITLE
Delete runtimes folder from packages until better support can be added

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -311,6 +311,10 @@
             // For now, delete src.  We may use it later...
             DeleteDirectory(packageInstallDirectory + "/src");
 
+            // Since we don't automatically fix up the runtime dll platforms, remove them until we improve support
+            // for this newer feature of nuget packages.
+            DeleteDirectory(Path.Combine(packageInstallDirectory, "runtimes"));
+
             // Delete documentation folders since they sometimes have HTML docs with JavaScript, which Unity tried to parse as "UnityScript"
             DeleteDirectory(packageInstallDirectory + "/docs");
 


### PR DESCRIPTION
Packages that have native dlls put them into runtime folders that are selected at runtime or when you elect a target platform. For Unity without removing this folder we end up with duplicate dlls that cause errors. I'm removing the directory for now until better support can come in for supporting and configuring the platform dlls in Unity native manners.