### PR TITLE
speed up refresh by issuing multiple GetUpdatesFallback requests in parallel

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -95,6 +95,11 @@
         private static string applicationDataPath = Application.dataPath;
 
         /// <summary>
+        /// Cached value of Application.temporaryCachePath, available for use from a background thread.
+        /// </summary>
+        private static string applicationTemporaryCachePath = Application.temporaryCachePath;
+
+        /// <summary>
         /// The current .NET version being used (2.0 [actually 3.5], 4.6, etc).
         /// </summary>
         internal static ApiCompatibilityLevel DotNetVersion;
@@ -1502,7 +1507,7 @@
 
         private static string GetFilePath(string url)
         {
-            return Path.Combine(Application.temporaryCachePath, GetHash(url));
+            return Path.Combine(applicationTemporaryCachePath, GetHash(url));
         }
 
         private static string GetHash(string s)

--- a/Assets/NuGet/Editor/NugetODataResponse.cs
+++ b/Assets/NuGet/Editor/NugetODataResponse.cs
@@ -62,11 +62,7 @@ namespace NugetForUnity
                 package.LicenseUrl = entryProperties.GetProperty("LicenseUrl");
                 package.ProjectUrl = entryProperties.GetProperty("ProjectUrl");
 
-                string iconUrl = entryProperties.GetProperty("IconUrl");
-                if (!string.IsNullOrEmpty(iconUrl))
-                {
-                    package.Icon = NugetHelper.DownloadImage(iconUrl);
-                }
+                package.IconUrl = entryProperties.GetProperty("IconUrl");
 
                 // if there is no title, just use the ID as the title
                 if (string.IsNullOrEmpty(package.Title))

--- a/Assets/NuGet/Editor/NugetPackage.cs
+++ b/Assets/NuGet/Editor/NugetPackage.cs
@@ -40,9 +40,9 @@
         public NugetPackageSource PackageSource;
 
         /// <summary>
-        /// Gets or sets the icon for the package as a <see cref="UnityEngine.Texture2D"/>. 
+        /// Gets or sets the URL of the icon for the package.
         /// </summary>
-        public UnityEngine.Texture2D Icon;
+        public string IconUrl;
 
         /// <summary>
         /// Gets or sets the NuGet packages that this NuGet package depends on.
@@ -75,6 +75,30 @@
         public string RepositoryCommit;
 
         /// <summary>
+        /// Gets the icon for the package as a <see cref="UnityEngine.Texture2D"/>. 
+        /// </summary>
+        public UnityEngine.Texture2D Icon
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(IconUrl))
+                    return null;
+
+                if (icon == null)
+                {
+                    // We load the actual Icon texture as it is first referenced.
+                    // This is done because package information is sometimes loaded on a background
+                    // thread that does not have the ability to create textures.
+                    icon = NugetHelper.DownloadImage(IconUrl);
+                    NugetHelper.LogVerbose("Loading icon from {0} {1}", IconUrl, icon != null ? "succeeded" : "failed");
+                }
+                return icon;
+            }
+        }
+
+        private UnityEngine.Texture2D icon;
+
+        /// <summary>
         /// Checks to see if this <see cref="NugetPackage"/> is equal to the given one.
         /// </summary>
         /// <param name="other">The other <see cref="NugetPackage"/> to check equality with.</param>
@@ -101,11 +125,7 @@
             package.LicenseUrl = nuspec.LicenseUrl;
             package.ProjectUrl = nuspec.ProjectUrl;
             //package.DownloadUrl = not in a nuspec
-
-            if (!string.IsNullOrEmpty(nuspec.IconUrl))
-            {
-                package.Icon = NugetHelper.DownloadImage(nuspec.IconUrl);
-            }
+            package.IconUrl = nuspec.IconUrl;
 
             package.RepositoryUrl = nuspec.RepositoryUrl;
 


### PR DESCRIPTION
Resolves #250 

use BeginInvoke to run GetUpdatesFallback on a background thread

Also includes changes to classes used by GetUpdatesFallback to avoid Unity functions that aren't allowed on a background thread.