### PR TITLE
Prevent package.config from being included in WSA Build Output

### DIFF
--- a/Assets/NuGet/Editor/NugetConfigFile.cs
+++ b/Assets/NuGet/Editor/NugetConfigFile.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using System.Text;
     using System.Xml.Linq;
+    using UnityEditor;
 
     /// <summary>
     /// Represents a NuGet.config file that stores the NuGet settings.
@@ -155,8 +156,9 @@
 
             configFile.Add(configuration);
 
+            bool fileExists = File.Exists(filepath);
             // remove the read only flag on the file, if there is one.
-            if (File.Exists(filepath))
+            if (fileExists)
             {
                 FileAttributes attributes = File.GetAttributes(filepath);
 
@@ -168,6 +170,8 @@
             }
 
             configFile.Save(filepath);
+
+            NugetHelper.DisableWSAPExportSetting(filepath, fileExists);
         }
 
         /// <summary>
@@ -180,7 +184,7 @@
             NugetConfigFile configFile = new NugetConfigFile();
             configFile.PackageSources = new List<NugetPackageSource>();
             configFile.InstallFromCache = true;
-            configFile.ReadOnlyPackageFiles = true;
+            configFile.ReadOnlyPackageFiles = false;
 
             XDocument file = XDocument.Load(filePath);
 
@@ -321,6 +325,10 @@
 </configuration>";
 
             File.WriteAllText(filePath, contents, new UTF8Encoding());
+
+            AssetDatabase.Refresh();
+
+            NugetHelper.DisableWSAPExportSetting(filePath, false);
 
             return Load(filePath);
         }

--- a/Assets/NuGet/Editor/NugetConfigFile.cs
+++ b/Assets/NuGet/Editor/NugetConfigFile.cs
@@ -188,6 +188,9 @@
 
             XDocument file = XDocument.Load(filePath);
 
+            // Force disable
+            NugetHelper.DisableWSAPExportSetting(filePath, false);
+
             // read the full list of package sources (some may be disabled below)
             XElement packageSources = file.Root.Element("packageSources");
             if (packageSources != null)

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1,18 +1,18 @@
 ﻿namespace NugetForUnity
 {
+    using Ionic.Zip;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Security.Cryptography;
     using System.Text;
-    using Ionic.Zip;
+    using System.Text.RegularExpressions;
     using UnityEditor;
     using UnityEngine;
     using Debug = UnityEngine.Debug;
-    using System.Security.Cryptography;
-    using System.Text.RegularExpressions;
 
     /// <summary>
     /// A set of helper methods that act as a wrapper around nuget.exe
@@ -24,6 +24,8 @@
     [InitializeOnLoad]
     public static class NugetHelper
     {
+        private static bool insideInitializeOnLoad = false;
+
         /// <summary>
         /// The path to the nuget.config file.
         /// </summary>
@@ -95,29 +97,37 @@
         /// </summary>
         static NugetHelper()
         {
-            // if we are entering playmode, don't do anything
-            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            insideInitializeOnLoad = true;
+            try
             {
-                return;
-            }
+                // if we are entering playmode, don't do anything
+                if (EditorApplication.isPlayingOrWillChangePlaymode)
+                {
+                    return;
+                }
 
 #if UNITY_5_6_OR_NEWER
-            DotNetVersion = PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup);
+                DotNetVersion = PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup);
 #else
             DotNetVersion = PlayerSettings.apiCompatibilityLevel;
 #endif
 
-            // Load the NuGet.config file
-            LoadNugetConfigFile();
+                // Load the NuGet.config file
+                LoadNugetConfigFile();
 
-            // create the nupkgs directory, if it doesn't exist
-            if (!Directory.Exists(PackOutputDirectory))
-            {
-                Directory.CreateDirectory(PackOutputDirectory);
+                // create the nupkgs directory, if it doesn't exist
+                if (!Directory.Exists(PackOutputDirectory))
+                {
+                    Directory.CreateDirectory(PackOutputDirectory);
+                }
+
+                // restore packages - this will be called EVERY time the project is loaded or a code-file changes
+                Restore();
             }
-
-            // restore packages - this will be called EVERY time the project is loaded or a code-file changes
-            Restore();
+            finally
+            {
+                insideInitializeOnLoad = false;
+            }
         }
 
         /// <summary>
@@ -142,7 +152,7 @@
             packageSources.Clear();
             bool readingSources = false;
             bool useCommandLineSources = false;
-            foreach (var arg in Environment.GetCommandLineArgs())
+            foreach (string arg in Environment.GetCommandLineArgs())
             {
                 if (readingSources)
                 {
@@ -273,13 +283,13 @@
             }
 
             string[] subdirectories = Directory.GetDirectories(directoryPath);
-            foreach (var subDir in subdirectories)
+            foreach (string subDir in subdirectories)
             {
                 FixSpaces(subDir);
             }
 
             string[] files = Directory.GetFiles(directoryPath);
-            foreach (var file in files)
+            foreach (string file in files)
             {
                 if (file.Contains("%20"))
                 {
@@ -297,11 +307,16 @@
         public static void DisableWSAPExportSetting(string filePath, bool notifyOfUpdate)
         {
             filePath = Path.GetFullPath(filePath);
-            PluginImporter importer = AssetImporter.GetAtPath(filePath.Replace(Path.GetFullPath(Application.dataPath), "Assets")) as PluginImporter;
+
+            string assetsLocalPath = filePath.Replace(Path.GetFullPath(Application.dataPath), "Assets");
+            PluginImporter importer = AssetImporter.GetAtPath(assetsLocalPath) as PluginImporter;
 
             if (importer == null)
             {
-                Debug.LogError(string.Format("Couldn't get importer for '{0}'.", filePath));
+                if (!insideInitializeOnLoad)
+                {
+                    Debug.LogError(string.Format("Couldn't get importer for '{0}'.", filePath));
+                }
                 return;
             }
 
@@ -357,11 +372,11 @@
                 bool using46 = intDotNetVersion == 3; // NET_4_6 = 3 in Unity 5.6 and Unity 2017.1 - use the hard-coded int value to ensure it works in earlier versions of Unity
                 bool usingStandard2 = intDotNetVersion == 6; // using .net standard 2.0                
 
-                var selectedDirectories = new List<string>();
+                List<string> selectedDirectories = new List<string>();
 
                 // go through the library folders in descending order (highest to lowest version)
-                var libDirectories = Directory.GetDirectories(packageInstallDirectory + "/lib").Select(s => new DirectoryInfo(s)).OrderByDescending(di => di.Name.ToLower());
-                foreach (var directory in libDirectories)
+                IOrderedEnumerable<DirectoryInfo> libDirectories = Directory.GetDirectories(packageInstallDirectory + "/lib").Select(s => new DirectoryInfo(s)).OrderByDescending(di => di.Name.ToLower());
+                foreach (DirectoryInfo directory in libDirectories)
                 {
                     string directoryName = directory.Name.ToLower();
 
@@ -476,13 +491,13 @@
                 }
 
 
-                foreach (var dir in selectedDirectories)
+                foreach (string dir in selectedDirectories)
                 {
                     LogVerbose("Using {0}", dir);
                 }
 
                 // delete all of the libaries except for the selected one
-                foreach (var directory in libDirectories)
+                foreach (DirectoryInfo directory in libDirectories)
                 {
                     bool validDirectory = selectedDirectories
                         .Where(d => string.Compare(d, directory.FullName, ignoreCase: true) == 0)
@@ -701,19 +716,21 @@
         private static void DeleteDirectory(string directoryPath)
         {
             if (!Directory.Exists(directoryPath))
+            {
                 return;
+            }
 
-            var directoryInfo = new DirectoryInfo(directoryPath);
+            DirectoryInfo directoryInfo = new DirectoryInfo(directoryPath);
 
             // delete any sub-folders first
-            foreach (var childInfo in directoryInfo.GetFileSystemInfos())
+            foreach (FileSystemInfo childInfo in directoryInfo.GetFileSystemInfos())
             {
                 DeleteDirectory(childInfo.FullName);
             }
 
             // remove the read-only flag on all files
-            var files = directoryInfo.GetFiles();
-            foreach (var file in files)
+            FileInfo[] files = directoryInfo.GetFiles();
+            foreach (FileInfo file in files)
             {
                 file.Attributes = FileAttributes.Normal;
             }
@@ -746,7 +763,7 @@
         private static void DeleteAllFiles(string directoryPath, string extension)
         {
             string[] files = Directory.GetFiles(directoryPath, extension, SearchOption.AllDirectories);
-            foreach (var file in files)
+            foreach (string file in files)
             {
                 DeleteFile(file);
             }
@@ -757,7 +774,7 @@
         /// </summary>
         internal static void UninstallAll()
         {
-            foreach (var package in installedPackages.Values.ToList())
+            foreach (NugetPackage package in installedPackages.Values.ToList())
             {
                 Uninstall(package);
             }
@@ -788,7 +805,9 @@
             installedPackages.Remove(package.Id);
 
             if (refreshAssets)
+            {
                 AssetDatabase.Refresh();
+            }
         }
 
         /// <summary>
@@ -909,9 +928,9 @@
             List<NugetPackage> packages = new List<NugetPackage>();
 
             // Loop through all active sources and combine them into a single list
-            foreach (var source in packageSources.Where(s => s.IsEnabled))
+            foreach (NugetPackageSource source in packageSources.Where(s => s.IsEnabled))
             {
-                var newPackages = source.Search(searchTerm, includeAllVersions, includePrerelease, numberToGet, numberToSkip);
+                List<NugetPackage> newPackages = source.Search(searchTerm, includeAllVersions, includePrerelease, numberToGet, numberToSkip);
                 packages.AddRange(newPackages);
                 packages = packages.Distinct().ToList();
             }
@@ -933,9 +952,9 @@
             List<NugetPackage> packages = new List<NugetPackage>();
 
             // Loop through all active sources and combine them into a single list
-            foreach (var source in packageSources.Where(s => s.IsEnabled))
+            foreach (NugetPackageSource source in packageSources.Where(s => s.IsEnabled))
             {
-                var newPackages = source.GetUpdates(packagesToUpdate, includePrerelease, includeAllVersions, targetFrameworks, versionContraints);
+                List<NugetPackage> newPackages = source.GetUpdates(packagesToUpdate, includePrerelease, includeAllVersions, targetFrameworks, versionContraints);
                 packages.AddRange(newPackages);
                 packages = packages.Distinct().ToList();
             }
@@ -1035,9 +1054,9 @@
             NugetPackage package = null;
 
             // Loop through all active sources and stop once the package is found
-            foreach (var source in packageSources.Where(s => s.IsEnabled))
+            foreach (NugetPackageSource source in packageSources.Where(s => s.IsEnabled))
             {
-                var foundPackage = source.GetSpecificPackage(packageId);
+                NugetPackage foundPackage = source.GetSpecificPackage(packageId);
                 if (foundPackage == null)
                 {
                     continue;
@@ -1117,7 +1136,7 @@
             if (NugetConfigFile.Verbose)
             {
 #if UNITY_5_4_OR_NEWER
-                var stackTraceLogType = Application.GetStackTraceLogType(LogType.Log);
+                StackTraceLogType stackTraceLogType = Application.GetStackTraceLogType(LogType.Log);
                 Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
 #else
                 var stackTraceLogType = Application.stackTraceLogType;
@@ -1168,16 +1187,18 @@
 
 
                 if (refreshAssets)
+                {
                     EditorUtility.DisplayProgressBar(string.Format("Installing {0} {1}", package.Id, package.Version), "Installing Dependencies", 0.1f);
+                }
 
                 // install all dependencies
-                foreach (var dependency in package.Dependencies)
+                foreach (NugetPackageIdentifier dependency in package.Dependencies)
                 {
                     LogVerbose("Installing Dependency: {0} {1}", dependency.Id, dependency.Version);
                     bool installed = InstallIdentifier(dependency);
                     if (!installed)
                     {
-                        throw new Exception(String.Format("Failed to install dependency: {0} {1}.", dependency.Id, dependency.Version));
+                        throw new Exception(string.Format("Failed to install dependency: {0} {1}.", dependency.Id, dependency.Version));
                     }
                 }
 
@@ -1216,7 +1237,9 @@
                         LogVerbose("Downloading package {0} {1}", package.Id, package.Version);
 
                         if (refreshAssets)
+                        {
                             EditorUtility.DisplayProgressBar(string.Format("Installing {0} {1}", package.Id, package.Version), "Downloading Package", 0.3f);
+                        }
 
                         Stream objStream = RequestUrl(package.DownloadUrl, package.PackageSource.UserName, package.PackageSource.ExpandedPassword, timeOut: null);
                         using (Stream file = File.Create(cachedPackagePath))
@@ -1227,7 +1250,9 @@
                 }
 
                 if (refreshAssets)
+                {
                     EditorUtility.DisplayProgressBar(string.Format("Installing {0} {1}", package.Id, package.Version), "Extracting Package", 0.6f);
+                }
 
                 if (File.Exists(cachedPackagePath))
                 {
@@ -1256,7 +1281,9 @@
                 }
 
                 if (refreshAssets)
+                {
                     EditorUtility.DisplayProgressBar(string.Format("Installing {0} {1}", package.Id, package.Version), "Cleaning Package", 0.9f);
+                }
 
                 // clean
                 Clean(package);
@@ -1386,11 +1413,11 @@
                 float currentProgress = 0;
 
                 // copy the list since the InstallIdentifier operation below changes the actual installed packages list
-                var packagesToInstall = new List<NugetPackageIdentifier>(PackagesConfigFile.Packages);
+                List<NugetPackageIdentifier> packagesToInstall = new List<NugetPackageIdentifier>(PackagesConfigFile.Packages);
 
                 LogVerbose("Restoring {0} packages.", packagesToInstall.Count);
 
-                foreach (var package in packagesToInstall)
+                foreach (NugetPackageIdentifier package in packagesToInstall)
                 {
                     if (package != null)
                     {
@@ -1429,16 +1456,18 @@
         internal static void CheckForUnnecessaryPackages()
         {
             if (!Directory.Exists(NugetConfigFile.RepositoryPath))
-                return;
-
-            var directories = Directory.GetDirectories(NugetConfigFile.RepositoryPath, "*", SearchOption.TopDirectoryOnly);
-            foreach (var folder in directories)
             {
-                var name = Path.GetFileName(folder);
-                var installed = false;
-                foreach (var package in PackagesConfigFile.Packages)
+                return;
+            }
+
+            string[] directories = Directory.GetDirectories(NugetConfigFile.RepositoryPath, "*", SearchOption.TopDirectoryOnly);
+            foreach (string folder in directories)
+            {
+                string name = Path.GetFileName(folder);
+                bool installed = false;
+                foreach (NugetPackageIdentifier package in PackagesConfigFile.Packages)
                 {
-                    var packageName = string.Format("{0}.{1}", package.Id, package.Version);
+                    string packageName = string.Format("{0}.{1}", package.Id, package.Version);
                     if (name == packageName)
                     {
                         installed = true;
@@ -1517,7 +1546,9 @@
                     LogVerbose("Downloading image {0} took {1} ms", url, stopwatch.ElapsedMilliseconds);
                 }
                 else
+                {
                     LogVerbose("Request error: " + request.error);
+                }
             }
 
 
@@ -1549,7 +1580,10 @@
         private static string GetHash(string s)
         {
             if (string.IsNullOrEmpty(s))
+            {
                 return null;
+            }
+
             MD5CryptoServiceProvider md5 = new MD5CryptoServiceProvider();
             byte[] data = md5.ComputeHash(Encoding.Default.GetBytes(s));
             StringBuilder sBuilder = new StringBuilder();
@@ -1584,7 +1618,7 @@
 
         private static void DownloadCredentialProviders(Uri feedUri)
         {
-            foreach (var feed in NugetHelper.knownAuthenticatedFeeds)
+            foreach (AuthenticatedFeed feed in NugetHelper.knownAuthenticatedFeeds)
             {
                 string account = feed.GetAccount(feedUri.ToString());
                 if (string.IsNullOrEmpty(account)) { continue; }
@@ -1606,7 +1640,7 @@
                     }
 
                     string providerDestination = Environment.GetEnvironmentVariable("NUGET_CREDENTIALPROVIDERS_PATH");
-                    if (String.IsNullOrEmpty(providerDestination))
+                    if (string.IsNullOrEmpty(providerDestination))
                     {
                         providerDestination = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Nuget/CredentialProviders");
                     }
@@ -1694,8 +1728,10 @@
 
             // Build the list of possible locations to find the credential provider. In order it should be local app data, paths set on the
             // environment varaible, and lastly look at the root of the pacakges save location.
-            List<string> possibleCredentialProviderPaths = new List<string>();
-            possibleCredentialProviderPaths.Add(Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Nuget"), "CredentialProviders"));
+            List<string> possibleCredentialProviderPaths = new List<string>
+            {
+                Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Nuget"), "CredentialProviders")
+            };
 
             string environmentCredentialProviderPaths = Environment.GetEnvironmentVariable("NUGET_CREDENTIALPROVIDERS_PATH");
             if (!string.IsNullOrEmpty(environmentCredentialProviderPaths))
@@ -1709,7 +1745,7 @@
             possibleCredentialProviderPaths.Add(toolsPackagesFolder);
 
             // Search through all possible paths to find the credential provider.
-            var providerPaths = new List<string>();
+            List<string> providerPaths = new List<string>();
             foreach (string possiblePath in possibleCredentialProviderPaths)
             {
                 if (Directory.Exists(possiblePath))
@@ -1718,7 +1754,7 @@
                 }
             }
 
-            foreach (var providerPath in providerPaths.Distinct())
+            foreach (string providerPath in providerPaths.Distinct())
             {
                 // Launch the credential provider executable and get the json encoded response from the std output
                 Process process = new Process();
@@ -1742,23 +1778,23 @@
                 {
                     case CredentialProviderExitCode.ProviderNotApplicable: break; // Not the right provider
                     case CredentialProviderExitCode.Failure: // Right provider, failure to get creds
-                        {
-                            Debug.LogErrorFormat("Failed to get credentials from {0}!\n\tOutput\n\t{1}\n\tErrors\n\t{2}", providerPath, output, errors);
-                            return null;
-                        }
+                    {
+                        Debug.LogErrorFormat("Failed to get credentials from {0}!\n\tOutput\n\t{1}\n\tErrors\n\t{2}", providerPath, output, errors);
+                        return null;
+                    }
                     case CredentialProviderExitCode.Success:
-                        {
-                            return JsonUtility.FromJson<CredentialProviderResponse>(output);
-                        }
+                    {
+                        return JsonUtility.FromJson<CredentialProviderResponse>(output);
+                    }
                     default:
-                        {
-                            Debug.LogWarningFormat("Unrecognized exit code {0} from {1} {2}", process.ExitCode, providerPath, process.StartInfo.Arguments);
-                            break;
-                        }
+                    {
+                        Debug.LogWarningFormat("Unrecognized exit code {0} from {1} {2}", process.ExitCode, providerPath, process.StartInfo.Arguments);
+                        break;
+                    }
                 }
             }
 
-            if(downloadIfMissing)
+            if (downloadIfMissing)
             {
                 DownloadCredentialProviders(feedUri);
                 return GetCredentialFromProvider_Uncached(feedUri, false);

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -306,6 +306,7 @@
         /// <param name="notifyOfUpdate">Whether or not to log a warning of the update.</param>
         public static void DisableWSAPExportSetting(string filePath, bool notifyOfUpdate)
         {
+#if UNITY_2018_1_OR_NEWER
             filePath = Path.GetFullPath(filePath);
 
             string assetsLocalPath = filePath.Replace(Path.GetFullPath(Application.dataPath), "Assets");
@@ -326,8 +327,14 @@
                 {
                     Debug.LogWarning(string.Format("Disabling WSA platform on asset settings for {0}", filePath));
                 }
+                else
+                {
+                    LogVerbose("Disabling WSA platform on asset settings for {0}", filePath);
+                }
+
                 importer.SetCompatibleWithPlatform(BuildTarget.WSAPlayer, false);
             }
+#endif
         }
 
         /// <summary>

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -306,7 +306,13 @@
         /// <param name="notifyOfUpdate">Whether or not to log a warning of the update.</param>
         public static void DisableWSAPExportSetting(string filePath, bool notifyOfUpdate)
         {
-#if UNITY_2018_1_OR_NEWER
+            string[] unityVersionParts = Application.unityVersion.Split('.');
+            int unityMajorVersion;
+            if (int.TryParse(unityVersionParts[0], out unityMajorVersion) && unityMajorVersion <= 2017)
+            {
+                return;
+            }
+
             filePath = Path.GetFullPath(filePath);
 
             string assetsLocalPath = filePath.Replace(Path.GetFullPath(Application.dataPath), "Assets");
@@ -334,7 +340,6 @@
 
                 importer.SetCompatibleWithPlatform(BuildTarget.WSAPlayer, false);
             }
-#endif
         }
 
         /// <summary>

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -290,6 +290,32 @@
         }
 
         /// <summary>
+        /// Checks the file importer settings and disables the export to WSA Platform setting.
+        /// </summary>
+        /// <param name="filePath">The path to the .config file.</param>
+        /// <param name="notifyOfUpdate">Whether or not to log a warning of the update.</param>
+        public static void DisableWSAPExportSetting(string filePath, bool notifyOfUpdate)
+        {
+            filePath = Path.GetFullPath(filePath);
+            PluginImporter importer = AssetImporter.GetAtPath(filePath.Replace(Path.GetFullPath(Application.dataPath), "Assets")) as PluginImporter;
+
+            if (importer == null)
+            {
+                Debug.LogError(string.Format("Couldn't get importer for '{0}'.", filePath));
+                return;
+            }
+
+            if (importer.GetCompatibleWithPlatform(BuildTarget.WSAPlayer))
+            {
+                if (notifyOfUpdate)
+                {
+                    Debug.LogWarning(string.Format("Disabling WSA platform on asset settings for {0}", filePath));
+                }
+                importer.SetCompatibleWithPlatform(BuildTarget.WSAPlayer, false);
+            }
+        }
+
+        /// <summary>
         /// Cleans up a package after it has been installed.
         /// Since we are in Unity, we can make certain assumptions on which files will NOT be used, so we can delete them.
         /// </summary>

--- a/Assets/NuGet/Editor/PackagesConfigFile.cs
+++ b/Assets/NuGet/Editor/PackagesConfigFile.cs
@@ -70,11 +70,13 @@
                 configFile.Save(filepath);
 
                 AssetDatabase.Refresh();
-
-                NugetHelper.DisableWSAPExportSetting(filepath, false);
             }
 
             XDocument packagesFile = XDocument.Load(filepath);
+
+            // Force disable
+            NugetHelper.DisableWSAPExportSetting(filepath, false);
+
             foreach (XElement packageElement in packagesFile.Root.Elements())
             {
                 NugetPackage package = new NugetPackage

--- a/Assets/NuGet/Editor/PackagesConfigFile.cs
+++ b/Assets/NuGet/Editor/PackagesConfigFile.cs
@@ -71,7 +71,7 @@
 
                 AssetDatabase.Refresh();
 
-                CheckImportSettings(filepath, false);
+                NugetHelper.DisableWSAPExportSetting(filepath, false);
             }
 
             XDocument packagesFile = XDocument.Load(filepath);
@@ -143,28 +143,7 @@
 
             packagesFile.Save(filepath);
 
-            CheckImportSettings(filepath, packageExists);
-        }
-
-        private static void CheckImportSettings(string filePath, bool notifyOfUpdate)
-        {
-            filePath = Path.GetFullPath(filePath);
-            PluginImporter importer = AssetImporter.GetAtPath(filePath.Replace(Path.GetFullPath(Application.dataPath), "Assets")) as PluginImporter;
-
-            if (importer == null)
-            {
-                Debug.LogError(string.Format("Couldn't get importer for '{0}'.", filePath));
-                return;
-            }
-
-            if (importer.GetCompatibleWithPlatform(BuildTarget.WSAPlayer))
-            {
-                if (notifyOfUpdate)
-                {
-                    Debug.LogWarning(string.Format("Disabling WSA platform on asset settings for {0}", filePath));
-                }
-                importer.SetCompatibleWithPlatform(BuildTarget.WSAPlayer, false);
-            }
+            NugetHelper.DisableWSAPExportSetting(filepath, packageExists);
         }
     }
 }


### PR DESCRIPTION
This is the fix for #280 issue.

When the packages.config file is created or updated, this change will check for it's asset importer settings and disable it as an asset for WSA build. This will prevent it from being included in the output of the IL2CPP build and causing errors during NuGet restore.

The change also includes some of my auto-formatting rules applied.