### PR TITLE
Delete ref folder as part of package cleanup

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -377,6 +377,10 @@
             // Delete documentation folders since they sometimes have HTML docs with JavaScript, which Unity tried to parse as "UnityScript"
             DeleteDirectory(packageInstallDirectory + "/docs");
 
+            // Delete ref folder, as it is just used for compile-time reference and does not contain implementations.
+            // Leaving it results in "assembly loading" and "multiple pre-compiled assemblies with same name" errors
+            DeleteDirectory(packageInstallDirectory + "/ref");
+
             if (Directory.Exists(packageInstallDirectory + "/lib"))
             {
                 int intDotNetVersion = (int)DotNetVersion; // c


### PR DESCRIPTION
Fixes the issue described in: https://github.com/GlitchEnzo/NuGetForUnity/issues/178

The root cause is that the ref folder contains stub dlls for various platforms that are used as a compiler reference in Visual Studio. In Unity, we just need the implementation dll from the lib folder.

Testing: Verified that after the change, I was able to install a package that included a dependency on the System.Numerics.Vectors package with no errors.