### PR TITLE
added trim to preferences path to remove leading or trailing whitespaces

### DIFF
--- a/Assets/NuGet/Editor/NugetPreferences.cs
+++ b/Assets/NuGet/Editor/NugetPreferences.cs
@@ -61,7 +61,7 @@
                         EditorGUILayout.BeginVertical();
                         {
                             source.Name = EditorGUILayout.TextField(source.Name);
-                            source.SavedPath = EditorGUILayout.TextField(source.SavedPath);
+                            source.SavedPath = EditorGUILayout.TextField(source.SavedPath).Trim();
                         }
                         EditorGUILayout.EndVertical();
                     }


### PR DESCRIPTION
fixes #249 where nuget package source urls couldn't be opened when there was a whitespace in the end of the url