### PR TITLE
 Improve correctness of dependency handling with regards to targetFrameworks

### DIFF
--- a/Assets/NuGet/Editor/DependencyTreeViewer.cs
+++ b/Assets/NuGet/Editor/DependencyTreeViewer.cs
@@ -107,7 +107,7 @@
             // remove a package as a root if another package is dependent on it
             foreach (NugetPackage package in installedPackages)
             {
-                NugetFrameworkGroup frameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
+                NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
                 foreach (NugetPackageIdentifier dependency in frameworkGroup.Dependencies)
                 {
                     roots.RemoveAll(p => p.Id == dependency.Id);
@@ -150,7 +150,7 @@
                         NugetPackage selectedPackage = installedPackages[selectedPackageIndex];
                         foreach (var package in installedPackages)
                         {
-                            NugetFrameworkGroup frameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
+                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
                             foreach (var dependency in frameworkGroup.Dependencies)
                             {
                                 if (dependency.Id == selectedPackage.Id)
@@ -211,7 +211,7 @@
                 {
                     EditorGUI.indentLevel++;
 
-                    NugetFrameworkGroup frameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
+                    NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
                     foreach (NugetPackageIdentifier dependency in frameworkGroup.Dependencies)
                     {
                         DrawDepencency(dependency);

--- a/Assets/NuGet/Editor/DependencyTreeViewer.cs
+++ b/Assets/NuGet/Editor/DependencyTreeViewer.cs
@@ -107,7 +107,8 @@
             // remove a package as a root if another package is dependent on it
             foreach (NugetPackage package in installedPackages)
             {
-                foreach (NugetPackageIdentifier dependency in package.Dependencies)
+                NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                foreach (NugetPackageIdentifier dependency in frameworkGroup.Dependencies)
                 {
                     roots.RemoveAll(p => p.Id == dependency.Id);
                 }
@@ -149,7 +150,8 @@
                         NugetPackage selectedPackage = installedPackages[selectedPackageIndex];
                         foreach (var package in installedPackages)
                         {
-                            foreach (var dependency in package.Dependencies)
+                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                            foreach (var dependency in frameworkGroup.Dependencies)
                             {
                                 if (dependency.Id == selectedPackage.Id)
                                 {
@@ -208,7 +210,9 @@
                 if (expanded[package])
                 {
                     EditorGUI.indentLevel++;
-                    foreach (NugetPackageIdentifier dependency in package.Dependencies)
+
+                    NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                    foreach (NugetPackageIdentifier dependency in frameworkGroup.Dependencies)
                     {
                         DrawDepencency(dependency);
                     }

--- a/Assets/NuGet/Editor/DependencyTreeViewer.cs
+++ b/Assets/NuGet/Editor/DependencyTreeViewer.cs
@@ -107,7 +107,7 @@
             // remove a package as a root if another package is dependent on it
             foreach (NugetPackage package in installedPackages)
             {
-                NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
+                NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
                 foreach (NugetPackageIdentifier dependency in frameworkGroup.Dependencies)
                 {
                     roots.RemoveAll(p => p.Id == dependency.Id);
@@ -150,7 +150,7 @@
                         NugetPackage selectedPackage = installedPackages[selectedPackageIndex];
                         foreach (var package in installedPackages)
                         {
-                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
+                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
                             foreach (var dependency in frameworkGroup.Dependencies)
                             {
                                 if (dependency.Id == selectedPackage.Id)
@@ -211,7 +211,7 @@
                 {
                     EditorGUI.indentLevel++;
 
-                    NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
+                    NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
                     foreach (NugetPackageIdentifier dependency in frameworkGroup.Dependencies)
                     {
                         DrawDepencency(dependency);

--- a/Assets/NuGet/Editor/DependencyTreeViewer.cs
+++ b/Assets/NuGet/Editor/DependencyTreeViewer.cs
@@ -107,7 +107,7 @@
             // remove a package as a root if another package is dependent on it
             foreach (NugetPackage package in installedPackages)
             {
-                NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                NugetFrameworkGroup frameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
                 foreach (NugetPackageIdentifier dependency in frameworkGroup.Dependencies)
                 {
                     roots.RemoveAll(p => p.Id == dependency.Id);
@@ -150,7 +150,7 @@
                         NugetPackage selectedPackage = installedPackages[selectedPackageIndex];
                         foreach (var package in installedPackages)
                         {
-                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                            NugetFrameworkGroup frameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
                             foreach (var dependency in frameworkGroup.Dependencies)
                             {
                                 if (dependency.Id == selectedPackage.Id)
@@ -211,7 +211,7 @@
                 {
                     EditorGUI.indentLevel++;
 
-                    NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                    NugetFrameworkGroup frameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
                     foreach (NugetPackageIdentifier dependency in frameworkGroup.Dependencies)
                     {
                         DrawDepencency(dependency);

--- a/Assets/NuGet/Editor/NugetFrameworkGroup.cs
+++ b/Assets/NuGet/Editor/NugetFrameworkGroup.cs
@@ -11,11 +11,11 @@ namespace NugetForUnity
         /// <summary>
         /// Gets or sets the framework and version that this group targets.
         /// </summary>
-        public string TargetFramework { get; set; }
+        public string TargetFramework { get; set; } = "";
 
         /// <summary>
         /// Gets or sets the list of package dependencies that belong to this group.
         /// </summary>
-        public List<NugetPackageIdentifier> Dependencies { get; set; }
+        public List<NugetPackageIdentifier> Dependencies { get; set; } = new List<NugetPackageIdentifier>();
     }
 }

--- a/Assets/NuGet/Editor/NugetFrameworkGroup.cs
+++ b/Assets/NuGet/Editor/NugetFrameworkGroup.cs
@@ -8,14 +8,20 @@ namespace NugetForUnity
     /// </summary>
     public class NugetFrameworkGroup
     {
+        public NugetFrameworkGroup()
+        {
+            TargetFramework = "";
+            Dependencies = new List<NugetPackageIdentifier>();
+        }
+
         /// <summary>
         /// Gets or sets the framework and version that this group targets.
         /// </summary>
-        public string TargetFramework { get; set; } = "";
+        public string TargetFramework { get; set; }
 
         /// <summary>
         /// Gets or sets the list of package dependencies that belong to this group.
         /// </summary>
-        public List<NugetPackageIdentifier> Dependencies { get; set; } = new List<NugetPackageIdentifier>();
+        public List<NugetPackageIdentifier> Dependencies { get; set; }
     }
 }

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -575,7 +575,7 @@
             // Add empty tfm (default) as last priority
             frameworkGroups.Add(new[] { "" });
 
-            var getTfmPriority = (string tfm) =>
+            Func<string, int> getTfmPriority = (string tfm) =>
             {
                 for (int i = 0; i < frameworkGroups.Count; ++i)
                 {
@@ -1178,7 +1178,7 @@
                 }
 
                 // install all dependencies for target framework
-                NugetFrameworkGroup frameworkGroup = TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
+                NugetFrameworkGroup frameworkGroup = GetBestDependencyFrameworkGroupForCurrentSettings(package);
 
                 LogVerbose("Installing dependencies for TargetFramework: {0}", frameworkGroup.TargetFramework);
                 foreach (var dependency in frameworkGroup.Dependencies)

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -90,7 +90,17 @@
         /// <summary>
         /// The current .NET version being used (2.0 [actually 3.5], 4.6, etc).
         /// </summary>
-        internal static ApiCompatibilityLevel DotNetVersion;
+        private static ApiCompatibilityLevel DotNetVersion
+        {
+            get
+            {
+#if UNITY_5_6_OR_NEWER
+                return PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup);
+#else
+                return PlayerSettings.apiCompatibilityLevel;
+#endif
+            }
+        }
 
         /// <summary>
         /// Static constructor used by Unity to initialize NuGet and restore packages defined in packages.config.
@@ -105,12 +115,6 @@
                 {
                     return;
                 }
-
-#if UNITY_5_6_OR_NEWER
-                DotNetVersion = PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup);
-#else
-                DotNetVersion = PlayerSettings.apiCompatibilityLevel;
-#endif
 
                 // Load the NuGet.config file
                 LoadNugetConfigFile();

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -533,7 +533,7 @@
             }
         }
 
-        public static NugetFrameworkGroup TryGetBestDependencyFrameworkGroupForCurrentSettings(NugetPackage package)
+        public static NugetFrameworkGroup GetBestDependencyFrameworkGroupForCurrentSettings(NugetPackage package)
         {
             var targetFrameworks = package.Dependencies
                 .Select(x => x.TargetFramework);
@@ -543,7 +543,7 @@
                 .FirstOrDefault(x => x.TargetFramework == bestTargetFramework) ?? new NugetFrameworkGroup();
         }
 
-        public static NugetFrameworkGroup TryGetBestDependencyFrameworkGroupForCurrentSettings(NuspecFile nuspec)
+        public static NugetFrameworkGroup GetBestDependencyFrameworkGroupForCurrentSettings(NuspecFile nuspec)
         {
             var targetFrameworks = nuspec.Dependencies
                 .Select(x => x.TargetFramework);
@@ -570,8 +570,10 @@
 
             if (usingStandard2) { frameworkGroups.Add(netStandardFrameworks); }
             else if (using46) { frameworkGroups.Add(net4Frameworks); }
+            else { frameworkGroups.Add(net3Frameworks); }
 
-            frameworkGroups.Add(net3Frameworks);
+            // Add empty tfm (default) as last priority
+            frameworkGroups.Add(new[] { "" });
 
             var getTfmPriority = (string tfm) =>
             {

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -598,7 +598,7 @@
                     {
                         return 6;
                     }
-                    else if (usingStandard2 && targetFramework == "netstandard1.3")
+                    else if ((using46 || usingStandard2) && targetFramework == "netstandard1.3")
                     {
                         return 7;
                     }
@@ -610,7 +610,7 @@
                     {
                         return 9;
                     }
-                    else if (usingStandard2 && targetFramework == "netstandard1.2")
+                    else if ((using46 || usingStandard2) && targetFramework == "netstandard1.2")
                     {
                         return 10;
                     }
@@ -618,11 +618,11 @@
                     {
                         return 11;
                     }
-                    else if (usingStandard2 && targetFramework == "netstandard1.1")
+                    else if ((using46 || usingStandard2) && targetFramework == "netstandard1.1")
                     {
                         return 12;
                     }
-                    else if (usingStandard2 && targetFramework == "netstandard1.0")
+                    else if ((using46 || usingStandard2) && targetFramework == "netstandard1.0")
                     {
                         return 13;
                     }

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -377,6 +377,10 @@
             // Delete documentation folders since they sometimes have HTML docs with JavaScript, which Unity tried to parse as "UnityScript"
             DeleteDirectory(packageInstallDirectory + "/docs");
 
+            // Delete ref folder, as it is just used for compile-time reference and does not contain implementations.
+            // Leaving it results in "assembly loading" and "multiple pre-compiled assemblies with same name" errors
+            DeleteDirectory(packageInstallDirectory + "/ref");
+
             if (Directory.Exists(packageInstallDirectory + "/lib"))
             {
                 int intDotNetVersion = (int)DotNetVersion; // c

--- a/Assets/NuGet/Editor/NugetODataResponse.cs
+++ b/Assets/NuGet/Editor/NugetODataResponse.cs
@@ -78,7 +78,6 @@ namespace NugetForUnity
                 }
 
                 // Get dependencies
-                package.Dependencies = new List<NugetPackageIdentifier>();
                 string rawDependencies = entryProperties.GetProperty("Dependencies");
                 if (!string.IsNullOrEmpty(rawDependencies))
                 {
@@ -104,98 +103,22 @@ namespace NugetForUnity
                             framework = details[2];
                         }
 
-                        NugetFrameworkGroup group;
-                        if (dependencyGroups.TryGetValue(framework, out group))
+                        if (dependencyGroups.TryGetValue(framework, out NugetFrameworkGroup group))
                         {
                             group.Dependencies.Add(dependency);
                         }
                         else
                         {
                             group = new NugetFrameworkGroup();
-                            group.Dependencies = new List<NugetPackageIdentifier>();
+                            group.TargetFramework = framework;
                             group.Dependencies.Add(dependency);
                             dependencyGroups.Add(framework, group);
                         }
                     }
 
-                    // find the correct group for this project
-                    int intDotNetVersion = (int)NugetHelper.DotNetVersion;
-                    //bool using46 = DotNetVersion == ApiCompatibilityLevel.NET_4_6; // NET_4_6 option was added in Unity 5.6
-                    bool using46 = intDotNetVersion == 3; // NET_4_6 = 3 in Unity 5.6 and Unity 2017.1 - use the hard-coded int value to ensure it works in earlier versions of Unity
-                    NugetFrameworkGroup selectedGroup = null;
-
-                    foreach (var kvPair in dependencyGroups.OrderByDescending(x => x.Key))
+                    foreach (var group in dependencyGroups.Values)
                     {
-                        string framework = kvPair.Key;
-                        NugetFrameworkGroup group = kvPair.Value;
-
-                        // Select the highest .NET library available that is supported
-                        // See here: https://docs.nuget.org/ndocs/schema/target-frameworks
-                        if (using46 && framework == "net462")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (using46 && framework == "net461")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (using46 && framework == "net46")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (using46 && framework == "net452")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (using46 && framework == "net451")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (using46 && framework == "net45")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (using46 && framework == "net403")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (using46 && (framework == "net40" || framework == "net4"))
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (framework == "net35")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (framework == "net20")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (framework == "net11")
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                        else if (framework == string.Empty)
-                        {
-                            selectedGroup = group;
-                            break;
-                        }
-                    }
-
-                    if (selectedGroup != null)
-                    {
-                        package.Dependencies = selectedGroup.Dependencies;
+                        package.Dependencies.Add(group);
                     }
                 }
 

--- a/Assets/NuGet/Editor/NugetPackage.cs
+++ b/Assets/NuGet/Editor/NugetPackage.cs
@@ -62,7 +62,7 @@
         /// <summary>
         /// Gets or sets the NuGet packages that this NuGet package depends on.
         /// </summary>
-        public List<NugetPackageIdentifier> Dependencies = new List<NugetPackageIdentifier>();
+        public List<NugetFrameworkGroup> Dependencies = new List<NugetFrameworkGroup>();
 
         /// <summary>
         /// Gets or sets the url for the location of the package's source code.

--- a/Assets/NuGet/Editor/NugetPackageSource.cs
+++ b/Assets/NuGet/Editor/NugetPackageSource.cs
@@ -32,7 +32,13 @@
         {
             get
             {
-                return Environment.ExpandEnvironmentVariables(SavedPath);
+                string path = Environment.ExpandEnvironmentVariables(SavedPath);
+                if (!path.StartsWith("http") && path != "(Aggregate source)" && !Path.IsPathRooted(path))
+                {
+                    path = Path.Combine(Path.GetDirectoryName(NugetHelper.NugetConfigFilePath), path);
+                }
+
+                return path;
             }
         }
 
@@ -275,10 +281,6 @@
             }
 
             string path = ExpandedPath;
-            if (!Path.IsPathRooted(path))
-            {
-                path = Path.Combine(Path.GetDirectoryName(NugetHelper.NugetConfigFilePath), path);
-            }
 
             if (Directory.Exists(path))
             {

--- a/Assets/NuGet/Editor/NugetPackageSource.cs
+++ b/Assets/NuGet/Editor/NugetPackageSource.cs
@@ -275,6 +275,10 @@
             }
 
             string path = ExpandedPath;
+            if (!Path.IsPathRooted(path))
+            {
+                path = Path.Combine(Path.GetDirectoryName(NugetHelper.NugetConfigFilePath), path);
+            }
 
             if (Directory.Exists(path))
             {

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -978,7 +978,7 @@
                             EditorStyles.label.fontStyle = FontStyle.Italic;
                             StringBuilder builder = new StringBuilder();
 
-                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                            NugetFrameworkGroup frameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
                             foreach (var dependency in frameworkGroup.Dependencies)
                             {
                                 builder.Append(string.Format(" {0} {1};", dependency.Id, dependency.Version));

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -978,7 +978,7 @@
                             EditorStyles.label.fontStyle = FontStyle.Italic;
                             StringBuilder builder = new StringBuilder();
 
-                            NugetFrameworkGroup frameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
+                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
                             foreach (var dependency in frameworkGroup.Dependencies)
                             {
                                 builder.Append(string.Format(" {0} {1};", dependency.Id, dependency.Version));

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -978,7 +978,7 @@
                             EditorStyles.label.fontStyle = FontStyle.Italic;
                             StringBuilder builder = new StringBuilder();
 
-                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
+                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
                             foreach (var dependency in frameworkGroup.Dependencies)
                             {
                                 builder.Append(string.Format(" {0} {1};", dependency.Id, dependency.Version));

--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -977,7 +977,9 @@
                             EditorStyles.label.wordWrap = true;
                             EditorStyles.label.fontStyle = FontStyle.Italic;
                             StringBuilder builder = new StringBuilder();
-                            foreach (var dependency in package.Dependencies)
+
+                            NugetFrameworkGroup frameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                            foreach (var dependency in frameworkGroup.Dependencies)
                             {
                                 builder.Append(string.Format(" {0} {1};", dependency.Id, dependency.Version));
                             }

--- a/Assets/NuGet/Editor/NuspecEditor.cs
+++ b/Assets/NuGet/Editor/NuspecEditor.cs
@@ -209,7 +209,8 @@
                             // remove a package as a root if another package is dependent on it
                             foreach (NugetPackage package in installedPackages)
                             {
-                                foreach (NugetPackageIdentifier dependency in package.Dependencies)
+                                NugetFrameworkGroup packageFrameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                                foreach (NugetPackageIdentifier dependency in packageFrameworkGroup.Dependencies)
                                 {
                                     roots.RemoveAll(p => p.Id == dependency.Id);
                                 }
@@ -218,14 +219,16 @@
                             // remove all existing dependencies from the .nuspec
                             nuspec.Dependencies.Clear();
 
-                            nuspec.Dependencies = roots.Cast<NugetPackageIdentifier>().ToList();
+                            nuspec.Dependencies.Add(new NugetFrameworkGroup());
+                            nuspec.Dependencies[0].Dependencies= roots.Cast<NugetPackageIdentifier>().ToList();
                         }
                     }
                     EditorGUILayout.EndHorizontal();
 
                     // display the dependencies
                     NugetPackageIdentifier toDelete = null;
-                    foreach (var dependency in nuspec.Dependencies)
+                    NugetFrameworkGroup nuspecFrameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(nuspec);
+                    foreach (var dependency in nuspecFrameworkGroup.Dependencies)
                     {
                         EditorGUILayout.BeginHorizontal();
                         GUILayout.Space(75);
@@ -264,7 +267,7 @@
 
                     if (toDelete != null)
                     {
-                        nuspec.Dependencies.Remove(toDelete);
+                        nuspecFrameworkGroup.Dependencies.Remove(toDelete);
                     }
 
                     EditorGUILayout.BeginHorizontal();
@@ -273,7 +276,7 @@
 
                         if (GUILayout.Button("Add Dependency"))
                         {
-                            nuspec.Dependencies.Add(new NugetPackageIdentifier());
+                            nuspecFrameworkGroup.Dependencies.Add(new NugetPackageIdentifier());
                         }
                     }
                     EditorGUILayout.EndHorizontal();

--- a/Assets/NuGet/Editor/NuspecEditor.cs
+++ b/Assets/NuGet/Editor/NuspecEditor.cs
@@ -209,7 +209,7 @@
                             // remove a package as a root if another package is dependent on it
                             foreach (NugetPackage package in installedPackages)
                             {
-                                NugetFrameworkGroup packageFrameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
+                                NugetFrameworkGroup packageFrameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
                                 foreach (NugetPackageIdentifier dependency in packageFrameworkGroup.Dependencies)
                                 {
                                     roots.RemoveAll(p => p.Id == dependency.Id);
@@ -227,7 +227,7 @@
 
                     // display the dependencies
                     NugetPackageIdentifier toDelete = null;
-                    NugetFrameworkGroup nuspecFrameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(nuspec);
+                    NugetFrameworkGroup nuspecFrameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(nuspec);
                     foreach (var dependency in nuspecFrameworkGroup.Dependencies)
                     {
                         EditorGUILayout.BeginHorizontal();

--- a/Assets/NuGet/Editor/NuspecEditor.cs
+++ b/Assets/NuGet/Editor/NuspecEditor.cs
@@ -209,7 +209,7 @@
                             // remove a package as a root if another package is dependent on it
                             foreach (NugetPackage package in installedPackages)
                             {
-                                NugetFrameworkGroup packageFrameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(package);
+                                NugetFrameworkGroup packageFrameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
                                 foreach (NugetPackageIdentifier dependency in packageFrameworkGroup.Dependencies)
                                 {
                                     roots.RemoveAll(p => p.Id == dependency.Id);
@@ -227,7 +227,7 @@
 
                     // display the dependencies
                     NugetPackageIdentifier toDelete = null;
-                    NugetFrameworkGroup nuspecFrameworkGroup = NugetHelper.GetBestTargetFrameworkForCurrentSettings(nuspec);
+                    NugetFrameworkGroup nuspecFrameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(nuspec);
                     foreach (var dependency in nuspecFrameworkGroup.Dependencies)
                     {
                         EditorGUILayout.BeginHorizontal();

--- a/Assets/NuGet/Editor/NuspecEditor.cs
+++ b/Assets/NuGet/Editor/NuspecEditor.cs
@@ -209,7 +209,7 @@
                             // remove a package as a root if another package is dependent on it
                             foreach (NugetPackage package in installedPackages)
                             {
-                                NugetFrameworkGroup packageFrameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(package);
+                                NugetFrameworkGroup packageFrameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(package);
                                 foreach (NugetPackageIdentifier dependency in packageFrameworkGroup.Dependencies)
                                 {
                                     roots.RemoveAll(p => p.Id == dependency.Id);
@@ -227,7 +227,7 @@
 
                     // display the dependencies
                     NugetPackageIdentifier toDelete = null;
-                    NugetFrameworkGroup nuspecFrameworkGroup = NugetHelper.GetBestDependencyFrameworkGroupForCurrentSettings(nuspec);
+                    NugetFrameworkGroup nuspecFrameworkGroup = NugetHelper.TryGetBestDependencyFrameworkGroupForCurrentSettings(nuspec);
                     foreach (var dependency in nuspecFrameworkGroup.Dependencies)
                     {
                         EditorGUILayout.BeginHorizontal();

--- a/Assets/NuGet/Editor/NuspecFile.cs
+++ b/Assets/NuGet/Editor/NuspecFile.cs
@@ -19,6 +19,7 @@
         public NuspecFile()
         {
             Dependencies = new List<NugetFrameworkGroup>();
+            Files = new List<NuspecContentFile>();
         }
 
         #region Required
@@ -121,7 +122,7 @@
         /// <summary>
         /// Gets or sets the list of content files listed in the .nuspec file.
         /// </summary>
-        public List<NuspecContentFile> Files { get; set; } = new List<NuspecContentFile>();
+        public List<NuspecContentFile> Files { get; set; }
 
         /// <summary>
         /// Loads the .nuspec file inside the .nupkg file at the given filepath.

--- a/Assets/NuGet/Editor/NuspecFile.cs
+++ b/Assets/NuGet/Editor/NuspecFile.cs
@@ -16,6 +16,11 @@
     /// </remarks>
     public class NuspecFile
     {
+        public NuspecFile()
+        {
+            Dependencies = new List<NugetFrameworkGroup>();
+        }
+
         #region Required
         /// <summary>
         /// Gets or sets the ID of the NuGet package.
@@ -76,7 +81,7 @@
         /// <summary>
         /// Gets or sets the NuGet packages that this NuGet package depends on.
         /// </summary>
-        public List<NugetFrameworkGroup> Dependencies { get; set; } = new List<NugetFrameworkGroup>();
+        public List<NugetFrameworkGroup> Dependencies { get; set; }
 
         /// <summary>
         /// Gets or sets the release notes of the NuGet package.


### PR DESCRIPTION
Currently, targetFrameworks are only checked when the nuget info retrieve from a nuget server, and then the "best" targetFramework is chosen as the list of dependencies. There are several issues with this fundamentally, as well as some bugs in the implementation:
* Dependencies are not enumerated at all when installing from a local package source
* If the target framework is changed, there is no way to get the correct dependency list other than by uninstall/reinstall.
* The "best" targetFramework detection was duplicated between NugetHelper and NugetODataResponse, with newer targets being neglected to be added to NugetODataResponse.
* "Best" framework was determined by directory ordering, which is fragile at best, and likely wrong in some cases.

To address these issues, I did the following:
* Updated NuspecFile.Dependencies to maintain the full list of frameworkGroups
* Updated callers to first get the best frameworkGroup, and then enumerate dependencies
* Refactored logic in NugetHelper to both increase robustness, and enable it to be shared throughout the codebase.
* Updated save/loadcode for Nuspec file to also parse <group> elements

Resolves #217 