### PR TITLE
Usability: Added a "Preferences" button to "Manage Nuget Packages" window.

### DIFF
--- a/Assets/NuGet/Editor/NugetWindow.cs
+++ b/Assets/NuGet/Editor/NugetWindow.cs
@@ -652,6 +652,16 @@ namespace NugetForUnity
                     {
                         Refresh(true);
                     }
+
+                    if (GUILayout.Button("Preferences", GUILayout.Width(80)))
+                    {
+#if UNITY_2018_3_OR_NEWER
+                        SettingsService.OpenUserPreferences("Preferences/NuGet For Unity");
+#else
+                        EditorApplication.ExecuteMenuItem("Edit/Preferences...");
+#endif
+                        GetWindow<NugetWindow>().Close();
+                    }
                 }
                 EditorGUILayout.EndHorizontal();
 
@@ -709,6 +719,20 @@ namespace NugetForUnity
             EditorGUILayout.BeginVertical(headerStyle);
             {
                 var enterPressed = Event.current.Equals(Event.KeyboardEvent("return"));
+
+                EditorGUILayout.BeginHorizontal();
+                {
+                    if (GUILayout.Button("Preferences", GUILayout.Width(80)))
+                    {
+#if UNITY_2018_3_OR_NEWER
+                        SettingsService.OpenUserPreferences("Preferences/NuGet For Unity");
+#else
+                        EditorApplication.ExecuteMenuItem("Edit/Preferences...");
+#endif
+                        GetWindow<NugetWindow>().Close();
+                    }
+                }
+                EditorGUILayout.EndHorizontal();
 
                 EditorGUILayout.BeginHorizontal();
                 {
@@ -771,6 +795,16 @@ namespace NugetForUnity
                     if (GUILayout.Button("Refresh", GUILayout.Width(60)))
                     {
                         Refresh(true);
+                    }
+
+                    if (GUILayout.Button("Preferences", GUILayout.Width(80)))
+                    {
+#if UNITY_2018_3_OR_NEWER
+                        SettingsService.OpenUserPreferences("Preferences/NuGet For Unity");
+#else
+                        EditorApplication.ExecuteMenuItem("Edit/Preferences...");
+#endif
+                        GetWindow<NugetWindow>().Close();
                     }
                 }
                 EditorGUILayout.EndHorizontal();


### PR DESCRIPTION
Added a "Preferences" button next to the "Refresh" button in "Manage Nuget Packages" window. When the button is pressed, it opens "Preferences/NuGet For Unity" window and closes the "Manage Nuget Packages" window. I decided to close the Manage window because most of the Preference options require the Manage window to be refreshed.

Fixes #232 