### PR TITLE
Do not use already imported in engine libraries while cleaning up

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1274,6 +1274,11 @@
         /// <param name="refreshAssets">True to refresh the Unity asset database.  False to ignore the changes (temporarily).</param>
         public static bool Install(NugetPackage package, bool refreshAssets = true)
         {
+            if (IsAlreadyImportedInEngine(package))
+            {
+                Debug.LogWarningFormat("Package {0} is already imported in engine", package);
+                return true;
+            }
             NugetPackage installedPackage = null;
             if (installedPackages.TryGetValue(package.Id, out installedPackage))
             {

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -570,8 +570,8 @@
                 Path.Combine(Directory.GetParent(executablePath).FullName, "Data")
             };
             var relativePaths = new[] {
-                Path.Combine("NetStandard",  "compat", "2.0.0", "shims", "netstandard"),
-                Path.Combine("MonoBleedingEdge", "lib", "mono", "4.7.1-api")
+                Path.Combine("NetStandard",  "compat"),
+                Path.Combine("MonoBleedingEdge", "lib", "mono")
             };
             var allPossiblePaths = roots
                 .SelectMany(root => relativePaths


### PR DESCRIPTION
Refers to https://github.com/GlitchEnzo/NuGetForUnity/issues/354

Fixes #354
Fixes #343 
Fixes #247
Fixes #320 
Fixes #322 
Fixes #330 
Fixes #336 