### PR TITLE
Change install API for package to avoid using deprecated nuget.org apis

### DIFF
--- a/Assets/NuGet/Editor/NugetODataResponse.cs
+++ b/Assets/NuGet/Editor/NugetODataResponse.cs
@@ -47,7 +47,16 @@ namespace NugetForUnity
         {
             List<NugetPackage> packages = new List<NugetPackage>();
 
-            var packageEntries = document.Root.Elements(XName.Get("entry", AtomNamespace));
+            IEnumerable<XElement> packageEntries;
+            if (document.Root.Name.Equals(XName.Get("entry", AtomNamespace)))
+            {
+                packageEntries = Enumerable.Repeat(document.Root, 1);
+            }
+            else
+            {
+                packageEntries = document.Root.Elements(XName.Get("entry", AtomNamespace));
+            }
+                
             foreach (var entry in packageEntries)
             {
                 NugetPackage package = new NugetPackage();


### PR DESCRIPTION
This change gets Unity back to working shape by avoiding use of soon to be deprecated v2 OData APIs.

Tested against: https://int.nugettest.org/api/v2/ and internal Azure DevOps feeds.

> Note: Nuget.org Search() API will only supports latest version so I'll be filing a separate issue for that problem.

Resolves #353 