### PR TITLE
Quick fix for V2 OData NuGet queries.

### DIFF
--- a/Assets/NuGet/Editor/NugetPackageSource.cs
+++ b/Assets/NuGet/Editor/NugetPackageSource.cs
@@ -133,7 +133,6 @@
             else
             {
                 // See here: http://www.odata.org/documentation/odata-version-2-0/uri-conventions/
-                // Note: without $orderby=Version, the Version filter below will not work
                 string url = string.Format("{0}FindPackagesById()?id='{1}'", ExpandedPath, package.Id);
                 
                 // Are we looking for a specific package?

--- a/Assets/NuGet/Editor/NugetPackageSource.cs
+++ b/Assets/NuGet/Editor/NugetPackageSource.cs
@@ -134,7 +134,7 @@
             {
                 // See here: http://www.odata.org/documentation/odata-version-2-0/uri-conventions/
                 // Note: without $orderby=Version, the Version filter below will not work
-                string url = string.Format("{0}FindPackagesById()?id='{1}'&$orderby=Version asc", ExpandedPath, package.Id);
+                string url = string.Format("{0}FindPackagesById()?id='{1}'", ExpandedPath, package.Id);
                 
                 // Are we looking for a specific package?
                 if (!package.HasVersionRange)


### PR DESCRIPTION
Some folks have hit the issue #383 with the recent changes to NuGet V2 OData support.  V2 OData queries are still supported, IF you drop ```&$orderby=Version asc``` in the request.  This probably breaks other things, but at least you can carry on using this in Unity for now.

See: https://devblogs.microsoft.com/nuget/custom-v2-odata-queries-will-be-deprecated-march-9-2021/