### PR TITLE
Handle Directory Entries in nupkg Files

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1404,6 +1404,7 @@
                             string filePath = Path.Combine(baseDirectory, entry.FullName);
                             string directory = Path.GetDirectoryName(filePath);
                             Directory.CreateDirectory(directory);
+                            if (Directory.Exists(filePath)) continue;
 
                             entry.ExtractToFile(filePath, overwrite: true);
 


### PR DESCRIPTION
Note that this includes PR #385.

Addresses issue #375.

Improvements:
- Detects if the entry in the zip archive is a directory and handles this correctly.

Tested against `Google.Protobuf` and `Microsoft.Extensions.Primitives` v2.0.0 (note latest Primitives doesn't have this issue)