### PR TITLE
Add configurable web request timeouts

### DIFF
--- a/Assets/NuGet/Editor/NugetConfigFile.cs
+++ b/Assets/NuGet/Editor/NugetConfigFile.cs
@@ -51,6 +51,11 @@
         public bool ReadOnlyPackageFiles { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating desired webrequest timeout in milliseconds.
+        /// </summary>
+        public int RequestTimeout { get; set; }
+
+        /// <summary>
         /// The incomplete path that is saved.  The path is expanded and made public via the property above.
         /// </summary>
         private string savedRepositoryPath;
@@ -150,6 +155,14 @@
                 config.Add(addElement);
             }
 
+            if (RequestTimeout > 0)
+            {
+                addElement = new XElement("add");
+                addElement.Add(new XAttribute("key", "RequestTimeout"));
+                addElement.Add(new XAttribute("value", RequestTimeout.ToString()));
+                config.Add(addElement);
+            }
+
             XElement configuration = new XElement("configuration");
             configuration.Add(packageSources);
             configuration.Add(disabledPackageSources);
@@ -188,6 +201,7 @@
             configFile.PackageSources = new List<NugetPackageSource>();
             configFile.InstallFromCache = true;
             configFile.ReadOnlyPackageFiles = false;
+            configFile.RequestTimeout = 5000;
 
             XDocument file = XDocument.Load(filePath);
 
@@ -300,6 +314,10 @@
                     else if (String.Equals(key, "ReadOnlyPackageFiles", StringComparison.OrdinalIgnoreCase))
                     {
                         configFile.ReadOnlyPackageFiles = bool.Parse(value);
+                    }
+                    else if (String.Equals(key, "RequestTimeout", StringComparison.OrdinalIgnoreCase))
+                    {
+                        configFile.RequestTimeout = int.Parse(value);
                     }
                 }
             }

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1379,7 +1379,7 @@
                             EditorUtility.DisplayProgressBar(string.Format("Installing {0} {1}", package.Id, package.Version), "Downloading Package", 0.3f);
                         }
 
-                        Stream objStream = RequestUrl(package.DownloadUrl, package.PackageSource.UserName, package.PackageSource.ExpandedPassword, timeOut: null);
+                        Stream objStream = RequestUrl(package.DownloadUrl, package.PackageSource.UserName, package.PackageSource.ExpandedPassword);
                         using (Stream file = File.Create(cachedPackagePath))
                         {
                             CopyStream(objStream, file);
@@ -1507,15 +1507,14 @@
         /// </summary>
         /// <param name="url">URL that will be loaded.</param>
         /// <param name="password">Password that will be passed in the Authorization header or the request. If null, authorization is omitted.</param>
-        /// <param name="timeOut">Timeout in milliseconds or null to use the default timeout values of HttpWebRequest.</param>
         /// <returns>Stream containing the result.</returns>
-        public static Stream RequestUrl(string url, string userName, string password, int? timeOut)
+        public static Stream RequestUrl(string url, string userName, string password)
         {
             HttpWebRequest getRequest = (HttpWebRequest)WebRequest.Create(url);
-            if (timeOut.HasValue)
+            if (NugetConfigFile.RequestTimeout > 0)
             {
-                getRequest.Timeout = timeOut.Value;
-                getRequest.ReadWriteTimeout = timeOut.Value;
+                getRequest.Timeout = NugetConfigFile.RequestTimeout;
+                getRequest.ReadWriteTimeout = NugetConfigFile.RequestTimeout;
             }
 
             if (string.IsNullOrEmpty(password))

--- a/Assets/NuGet/Editor/NugetPackageSource.cs
+++ b/Assets/NuGet/Editor/NugetPackageSource.cs
@@ -373,7 +373,7 @@
             // add anonymous handler
             ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, policyErrors) => true;
 
-            using (Stream responseStream = NugetHelper.RequestUrl(url, username, password, timeOut: 5000))
+            using (Stream responseStream = NugetHelper.RequestUrl(url, username, password))
             {
                 using (StreamReader streamReader = new StreamReader(responseStream))
                 {

--- a/Assets/NuGet/Editor/NugetPreferences.cs
+++ b/Assets/NuGet/Editor/NugetPreferences.cs
@@ -54,6 +54,13 @@
                 NugetHelper.NugetConfigFile.Verbose = verbose;
             }
 
+            int timeout = EditorGUILayout.IntField("Web Request Timeout", NugetHelper.NugetConfigFile.RequestTimeout);
+            if (timeout != NugetHelper.NugetConfigFile.RequestTimeout)
+            {
+                preferencesChangedThisFrame = true;
+                NugetHelper.NugetConfigFile.RequestTimeout = timeout;
+            }
+
             EditorGUILayout.LabelField("Package Sources:");
 
             scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);


### PR DESCRIPTION
I had some issues with installs timing out, so I needed to add a config option to set a custom timeout for all Nuget operations. I also removed the hardcoded defaults to always use the config file setting, which stays at the original default of 5000ms. Thought it made sense as a feature for others 👍🏻 