### PR TITLE
Support hyphen in Azure org account name

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1492,7 +1492,7 @@
         {
             new AuthenticatedFeed()
             {
-                AccountUrlPattern = @"^https:\/\/(?<account>[a-zA-z0-9]+).pkgs.visualstudio.com",
+                AccountUrlPattern = @"^https:\/\/(?<account>[-a-zA-z0-9]+).pkgs.visualstudio.com",
                 ProviderUrlTemplate = "https://{account}.pkgs.visualstudio.com/_apis/public/nuget/client/CredentialProviderBundle.zip"
             },
             new AuthenticatedFeed()

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1497,7 +1497,7 @@
             },
             new AuthenticatedFeed()
             {
-                AccountUrlPattern = @"^https:\/\/pkgs.dev.azure.com\/(?<account>[a-zA-z0-9]+)\/",
+                AccountUrlPattern = @"^https:\/\/pkgs.dev.azure.com\/(?<account>[-a-zA-z0-9]+)\/",
                 ProviderUrlTemplate = "https://pkgs.dev.azure.com/{account}/_apis/public/nuget/client/CredentialProviderBundle.zip"
             }
         };


### PR DESCRIPTION
As recently discussed on #362, we would fail to get the correct provider when an Azure feed pointed to an organization with a hyphen in its name.

When creating an organization under Azure DevOps, the following rules for naming apply:
- Should start with a letter or number only;
- Should end with a letter or number only;
- In between, it can only contain letters, numbers, and hyphens.

This commit adds the hyphen character to the list of supported ones in the regex that is used to look for the account name in the feed URL. Since the rules are enforced on creation, I didn't add any complexity to the regex by trying to follow the naming convention.

I don't know if the same applies to the other rule, but in case anyone does I can add easily patch it too.