### PR TITLE
Fix package restore happening on every script recompilation in projects

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -110,12 +110,12 @@
             insideInitializeOnLoad = true;
             try
             {
-                if (SessionState.GetBool("FirstProjectOpen", false))
+                if (SessionState.GetBool("NugetForUnity.FirstProjectOpen", false))
                 {
                     return;
                 }
 
-                SessionState.SetBool("FirstProjectOpen", true);
+                SessionState.SetBool("NugetForUnity.FirstProjectOpen", true);
                 
                 // if we are entering playmode, don't do anything
                 if (EditorApplication.isPlayingOrWillChangePlaymode)

--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -110,6 +110,13 @@
             insideInitializeOnLoad = true;
             try
             {
+                if (SessionState.GetBool("FirstProjectOpen", false))
+                {
+                    return;
+                }
+
+                SessionState.SetBool("FirstProjectOpen", true);
+                
                 // if we are entering playmode, don't do anything
                 if (EditorApplication.isPlayingOrWillChangePlaymode)
                 {


### PR DESCRIPTION
When NuGetForUnity is included in a user project, and they make changes to their scripts, Unity also reloads the editor scripts for NuGetForUnity, which will then retrigger the static NugetHelper constructor because it is marked as InitializeOnLoad. Because this constructor restores packages, a package restore is done every script reload. Usually this amounts to no actual change because the packages in question are already installed, but just checking one or two packages this way can already slow down the script recompilation process by several seconds, which quickly becomes tiresome.

This changes the restore to only happen once on project start-up, fixing the issue. There was also little benefit to the restore happening, as it didn't happen automatically when packages.config was modified, which would have been the most useful and already requires a manual reload.

Solution was proposed by @Shii2 in #407. I just formalized the change in a PR, also skipped doing I/O to check if the packages folder exists every time, and tested in a Unity 2020.3.20f1 project that it works as intended. Checks done:

- [x] Starting up a project still restores packages.
- [x] Making a change to a script no longer restores packages, even multiple times in succession.