### PR TITLE
Fix issue #376: Local Relative Path Source Shows Packages, Fails to Install 

### DIFF
--- a/Assets/NuGet/Editor/NugetPackageSource.cs
+++ b/Assets/NuGet/Editor/NugetPackageSource.cs
@@ -185,6 +185,7 @@
                 if (File.Exists(localPackagePath))
                 {
                     NugetPackage localPackage = NugetPackage.FromNupkgFile(localPackagePath);
+                    localPackage.PackageSource = this;
                     return localPackage;
                 }
                 else


### PR DESCRIPTION
The cause of issue #376 is a simple oversight in `NugetPackageSource.GetSpecificPackage`. Previously, local packages when found in this method will not have their `PackageSource` field initialized. The fix is just 1 line to assign the current package source to said field.