### PR TITLE
fix: automatically decompress NuGet stream

### DIFF
--- a/Assets/NuGet/Editor/NugetHelper.cs
+++ b/Assets/NuGet/Editor/NugetHelper.cs
@@ -1512,6 +1512,7 @@
         public static Stream RequestUrl(string url, string userName, string password, int? timeOut)
         {
             HttpWebRequest getRequest = (HttpWebRequest)WebRequest.Create(url);
+            getRequest.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.None;
             if (timeOut.HasValue)
             {
                 getRequest.Timeout = timeOut.Value;


### PR DESCRIPTION
NuGet.org has started to return compressed streams which breaks NuGetForUnity, adding automatic decompression solves the issue