### PR TITLE
Use long for 'DownloadCount' instead of int.

### DIFF
--- a/Assets/NuGet/Editor/NugetODataResponse.cs
+++ b/Assets/NuGet/Editor/NugetODataResponse.cs
@@ -72,7 +72,7 @@ namespace NugetForUnity
                 package.LicenseUrl = entryProperties.GetProperty("LicenseUrl");
                 package.ProjectUrl = entryProperties.GetProperty("ProjectUrl");
                 package.Authors = entryProperties.GetProperty("Authors");
-                package.DownloadCount = int.Parse(entryProperties.GetProperty("DownloadCount"));
+                package.DownloadCount = long.Parse(entryProperties.GetProperty("DownloadCount"));
 
                 string iconUrl = entryProperties.GetProperty("IconUrl");
                 if (!string.IsNullOrEmpty(iconUrl))

--- a/Assets/NuGet/Editor/NugetPackage.cs
+++ b/Assets/NuGet/Editor/NugetPackage.cs
@@ -42,7 +42,7 @@
         /// <summary>
         /// Gets or sets the DownloadCount.
         /// </summary>
-        public int DownloadCount;
+        public long DownloadCount;
 
         /// <summary>
         /// Gets or sets the authors of the package.


### PR DESCRIPTION
To prevent overflow for packages with a lot of downloads.

Fixes probably:
https://github.com/GlitchEnzo/NuGetForUnity/issues/461
https://github.com/GlitchEnzo/NuGetForUnity/issues/463

Btw. github action would be nice, and easier to check if everything works, especially for linux users