### PR TITLE
Skip .svn subdirectory

### DIFF
--- a/src/NuGetForUnity/Editor/NugetHelper.cs
+++ b/src/NuGetForUnity/Editor/NugetHelper.cs
@@ -1403,12 +1403,14 @@ namespace NugetForUnity
             var directories = Directory.GetDirectories(NugetConfigFile.RepositoryPath, "*", SearchOption.TopDirectoryOnly);
             foreach (var folder in directories)
             {
-                if (Path.GetFileName(folder) == ".svn")
+                var folderName = Path.GetFileName(folder);
+                if (folderName.Equals(".svn", StringComparison.OrdinalIgnoreCase))
                 {
+                    // ignore folder required by SVN tool
                     continue;
                 }
 
-                var pkgPath = Path.Combine(folder, $"{Path.GetFileName(folder)}.nupkg");
+                var pkgPath = Path.Combine(folder, $"{folderName}.nupkg");
                 var package = NugetPackage.FromNupkgFile(pkgPath);
 
                 var installed = false;

--- a/src/NuGetForUnity/Editor/NugetHelper.cs
+++ b/src/NuGetForUnity/Editor/NugetHelper.cs
@@ -1403,6 +1403,11 @@ namespace NugetForUnity
             var directories = Directory.GetDirectories(NugetConfigFile.RepositoryPath, "*", SearchOption.TopDirectoryOnly);
             foreach (var folder in directories)
             {
+                if (Path.GetFileName(folder) == ".svn")
+                {
+                    continue;
+                }
+
                 var pkgPath = Path.Combine(folder, $"{Path.GetFileName(folder)}.nupkg");
                 var package = NugetPackage.FromNupkgFile(pkgPath);
 


### PR DESCRIPTION
Older SVN versions will create a .svn subdirectory in each directory of the repo. If one is present in the RepositoryPath, skip it, otherwise it will be removed, damaging the repo.