### PR TITLE
Enhance finding already imported Assemblies

### DIFF
--- a/src/NuGetForUnity/Editor/UnityPreImportedLibraryResolver.cs
+++ b/src/NuGetForUnity/Editor/UnityPreImportedLibraryResolver.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEditor;
+using UnityEditor.Compilation;
 
 namespace NugetForUnity
 {
@@ -19,33 +19,51 @@ namespace NugetForUnity
         /// <returns>A set of all names of libraries that are already imported by unity.</returns>
         internal static HashSet<string> GetAlreadyImportedLibs()
         {
-            if (alreadyImportedLibs == null)
+            if (alreadyImportedLibs != null)
             {
-                // Find all the dll's already installed by NuGetForUnity
-                var alreadyInstalledDllFileNames = new HashSet<string>();
-
-                if (NugetHelper.NugetConfigFile != null && Directory.Exists(NugetHelper.NugetConfigFile.RepositoryPath))
-                {
-                    alreadyInstalledDllFileNames = new HashSet<string>(
-                        Directory.EnumerateFiles(NugetHelper.NugetConfigFile.RepositoryPath, "*.dll", SearchOption.AllDirectories)
-                            .Select(Path.GetFileNameWithoutExtension));
-                }
-
-                // Get all assemblies loaded into Unity and filter out those installed by NuGetForUnity
-                alreadyImportedLibs = new HashSet<string>(
-                    AppDomain.CurrentDomain.GetAssemblies()
-                        .Select(assembly => Path.GetFileNameWithoutExtension(assembly.ManifestModule.Name))
-                        .Where(p => !alreadyInstalledDllFileNames.Contains(p)));
-
-                if (PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup) ==
-                    ApiCompatibilityLevel.NET_Standard_2_0)
-                {
-                    alreadyImportedLibs.Add("NETStandard.Library");
-                    alreadyImportedLibs.Add("Microsoft.NETCore.Platforms");
-                }
-
-                NugetHelper.LogVerbose("Already imported libs: {0}", string.Join(", ", alreadyImportedLibs));
+                return alreadyImportedLibs;
             }
+
+            // Find all the assemblies already installed by NuGetForUnity
+            var alreadyInstalledDllFileNames = new HashSet<string>();
+
+            if (NugetHelper.NugetConfigFile != null && Directory.Exists(NugetHelper.NugetConfigFile.RepositoryPath))
+            {
+                alreadyInstalledDllFileNames = new HashSet<string>(
+                    Directory.EnumerateFiles(NugetHelper.NugetConfigFile.RepositoryPath, "*.dll", SearchOption.AllDirectories)
+                        .Select(Path.GetFileNameWithoutExtension));
+            }
+
+            // Search the all project assemblies that are not from a package or a Unity assembly.
+            // We only use player assemblies as we don't need to collect UnityEditor assemblies, we don't support installing NuGet packages with reference to UnityEditor.
+#if UNITY_2019_3_OR_NEWER
+            const AssembliesType assemblieType = AssembliesType.PlayerWithoutTestAssemblies;
+#else
+            const AssembliesType assemblieType = AssembliesType.Player;
+#endif
+            var projectAssemblies = CompilationPipeline.GetAssemblies(assemblieType)
+                .Where(
+                    playerAssembly => playerAssembly.sourceFiles.Length == 0 ||
+                                      playerAssembly.sourceFiles.Any(
+                                          sourceFilePath => sourceFilePath.StartsWith("Assets/") || sourceFilePath.StartsWith("Assets\\")));
+
+            // Collect all referenced assemblies but exclude all assemblies installed by NuGetForUnity.
+            var porojectReferences = projectAssemblies.SelectMany(playerAssembly => playerAssembly.allReferences);
+            alreadyImportedLibs = new HashSet<string>(
+                porojectReferences.Select(compiledAssemblyReference => Path.GetFileNameWithoutExtension(compiledAssemblyReference))
+                    .Where(assemblyName => !alreadyInstalledDllFileNames.Contains(assemblyName)));
+
+            if (PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup) == ApiCompatibilityLevel.NET_Standard_2_0)
+            {
+                // mark NuGet packages that contain the .net standard references as already imported
+                alreadyImportedLibs.Add("NETStandard.Library");
+                alreadyImportedLibs.Add("Microsoft.NETCore.Platforms");
+            }
+
+            // the compiler / language is available by default
+            alreadyImportedLibs.Add("Microsoft.CSharp");
+
+            NugetHelper.LogVerbose("Already imported libs: {0}", string.Join(", ", alreadyImportedLibs));
 
             return alreadyImportedLibs;
         }

--- a/src/TestProjects/ImportAndUseNuGetPackages/Assets/NuGet.config.meta
+++ b/src/TestProjects/ImportAndUseNuGetPackages/Assets/NuGet.config.meta
@@ -1,5 +1,7 @@
 fileFormatVersion: 2
 guid: 1830bbd65d23ca44091295302510f9ba
+labels:
+- NuGetForUnity
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/src/TestProjects/ImportAndUseNuGetPackages/Assets/packages.config.meta
+++ b/src/TestProjects/ImportAndUseNuGetPackages/Assets/packages.config.meta
@@ -1,5 +1,7 @@
 fileFormatVersion: 2
 guid: 92ff8dfaac1bac641aca1499e5f70d94
+labels:
+- NuGetForUnity
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/tools/format-staged.ps1
+++ b/tools/format-staged.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Resolve-Path $PSScriptRoot\..
+$currentLocation = Get-Location
+
+try {
+    Set-Location $repositoryRoot
+    . pre-commit run --verbose
+}
+finally {
+    Set-Location $currentLocation
+}


### PR DESCRIPTION
- use `CompilationPipeline.GetAssemblies` to find libraries pre imported by unity 
- add `Microsoft.CSharp` to `alreadyImportedLibs`