### PR TITLE
Fix deletion of non nuget-packages

### DIFF
--- a/src/NuGetForUnity/Editor/NugetHelper.cs
+++ b/src/NuGetForUnity/Editor/NugetHelper.cs
@@ -1430,7 +1430,13 @@ namespace NugetForUnity
                     continue;
                 }
 
-                var pkgPath = Path.Combine(folder, $"{folderName}.nupkg");
+                var pkgPath = Path.Combine(folder, $"{folderName}.nupkg");                
+                if (!File.Exists(pkgPath))
+                {
+                    // ignore folder not containing a nuget-package
+                    continue;
+                }
+                
                 var package = NugetPackage.FromNupkgFile(pkgPath);
 
                 var installed = false;


### PR DESCRIPTION
Only delete unnecessary directories that contain a NuGet Package

Fixes #344 #455 #402 #392