### PR TITLE
Fix InstallAndSearchLocalPackageSource test + update unity 2018

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,7 +178,6 @@ jobs:
           projectPath: src/NuGetForUnity.Tests
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: EditMode
-          customParameters: -nographics
 
   runTestProjectsOnLinux:
     name: Run test projects on linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,6 +177,8 @@ jobs:
         with:
           projectPath: src/NuGetForUnity.Tests
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          testMode: EditMode
+          customParameters: -nographics
 
   runTestProjectsOnLinux:
     name: Run test projects on linux

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -28,6 +28,7 @@ public class NuGetTests
     }
 
     [Test]
+    [Order(1)]
     public void SimpleRestoreTest()
     {
         NugetHelper.Restore();
@@ -254,7 +255,7 @@ public class NuGetTests
     public void InstallAndSearchLocalPackageSource([Values] bool hierarchical)
     {
         var package = new NugetPackageIdentifier("protobuf-net", "2.0.0.668") { IsManuallyInstalled = true };
-        var tempDirectoryPath = Path.GetFullPath("TempUnitTestFolder");
+        var tempDirectoryPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "TempUnitTestFolder"));
         Directory.CreateDirectory(tempDirectoryPath);
         File.Copy(NugetHelper.NugetConfigFilePath, Path.Combine(tempDirectoryPath, NugetConfigFile.FileName));
 

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -28,7 +28,6 @@ public class NuGetTests
     }
 
     [Test]
-    [Order(1)]
     public void SimpleRestoreTest()
     {
         NugetHelper.Restore();
@@ -254,6 +253,7 @@ public class NuGetTests
     [Test]
     public void InstallAndSearchLocalPackageSource([Values] bool hierarchical)
     {
+        NugetHelper.LoadNugetConfigFile(); // ensure 'NuGet.config' exists
         var package = new NugetPackageIdentifier("protobuf-net", "2.0.0.668") { IsManuallyInstalled = true };
         var tempDirectoryPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "TempUnitTestFolder"));
         Directory.CreateDirectory(tempDirectoryPath);

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -41,6 +41,7 @@ public class NuGetTests
     }
 
     [Test]
+    [Order(2)]
     public void InstallJsonTest()
     {
         // install a specific version

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -10,10 +11,20 @@ using UnityEngine;
 
 public class NuGetTests
 {
+    private Stopwatch stopwatch;
+
+    [SetUp]
+    public void Setup()
+    {
+        stopwatch = Stopwatch.StartNew();
+        TestContext.Progress.WriteLine($"Test: {TestContext.CurrentContext.Test.FullName}");
+    }
+
     [TearDown]
     public void Cleanup()
     {
         NugetHelper.UninstallAll(NugetHelper.InstalledPackages.ToList());
+        TestContext.Progress.WriteLine($"Test: {TestContext.CurrentContext.Test.FullName}, Duration: {stopwatch.Elapsed}");
     }
 
     [Test]
@@ -604,8 +615,7 @@ public class NuGetTests
 
         var assetsIndex = filepath.LastIndexOf("Assets", StringComparison.Ordinal);
         filepath = filepath.Substring(assetsIndex);
-        NugetPackageAssetPostprocessor.OnPostprocessAllAssets(new[]{filepath},
-            null, null, null);
+        NugetPackageAssetPostprocessor.OnPostprocessAllAssets(new[] { filepath }, null, null, null);
 
         Assert.IsFalse(NugetHelper.IsInstalled(package), "The package is STILL installed: {0} {1}", package.Id, package.Version);
     }

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -28,6 +28,7 @@ public class NuGetTests
     }
 
     [Test]
+    [Order(1)]
     public void SimpleRestoreTest()
     {
         NugetHelper.Restore();

--- a/src/NuGetForUnity.Tests/Packages/manifest.json
+++ b/src/NuGetForUnity.Tests/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.analytics": "3.2.3",
     "com.unity.collab-proxy": "1.2.15",
     "com.unity.package-manager-ui": "2.0.13",
-    "com.unity.purchasing": "2.1.1",
+    "com.unity.purchasing": "2.2.1",
     "com.unity.textmeshpro": "1.4.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/src/NuGetForUnity.Tests/ProjectSettings/ProjectVersion.txt
+++ b/src/NuGetForUnity.Tests/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.4.30f1
+m_EditorVersion: 2018.4.36f1


### PR DESCRIPTION
Fix UnitTest getting stuck in GitHub Action see https://github.com/game-ci/unity-test-runner/issues/188
- Fix InstallAndSearchLocalPackageSource test
- update to unity 2018.4.36f1
- log running test to find failing test
- change GitHub Action to only execute EditMode tests

In my tests this resoled the "UnitTest getting stuck in GitHub Action" but eventually we need to update `unity-test-runner` if they improve the logging (mentioned in the issue).