### PR TITLE
Made packages.config path configurable from NuGet preferences

### DIFF
--- a/src/NuGetForUnity.Cli/Fakes/Application.cs
+++ b/src/NuGetForUnity.Cli/Fakes/Application.cs
@@ -20,6 +20,22 @@ namespace UnityEngine
 
         public static ApiCompatibilityLevel ApiCompatibilityLevel { get; private set; }
 
+        public static RuntimePlatform platform
+        {
+            get
+            {
+                switch (Environment.OSVersion.Platform)
+                {
+                    case PlatformID.MacOSX:
+                        return RuntimePlatform.OSXEditor;
+                    case PlatformID.Unix:
+                        return RuntimePlatform.LinuxEditor;
+                    default:
+                        return RuntimePlatform.WindowsEditor;
+                }
+            }
+        }
+
         internal static StackTraceLogType GetStackTraceLogType(LogType log)
         {
             return StackTraceLogType.None;

--- a/src/NuGetForUnity.Cli/Fakes/Debug.cs
+++ b/src/NuGetForUnity.Cli/Fakes/Debug.cs
@@ -43,6 +43,12 @@ namespace UnityEngine
             Console.Error.WriteLine(format, args);
         }
 
+        internal static void LogException(Exception e)
+        {
+            HasError = true;
+            Console.Error.WriteLine(e.ToString());
+        }
+
         internal static void Assert(bool condition)
         {
             System.Diagnostics.Debug.Assert(condition);

--- a/src/NuGetForUnity.Cli/Fakes/RuntimePlatform.cs
+++ b/src/NuGetForUnity.Cli/Fakes/RuntimePlatform.cs
@@ -1,0 +1,12 @@
+#nullable enable
+namespace UnityEngine
+{
+    public enum RuntimePlatform
+    {
+        OSXEditor = 0,
+
+        WindowsEditor = 7,
+
+        LinuxEditor = 16
+    }
+}

--- a/src/NuGetForUnity.Tests/Assets/NuGet.config
+++ b/src/NuGetForUnity.Tests/Assets/NuGet.config
@@ -11,7 +11,7 @@
   </activePackageSource>
   <config>
     <add key="repositoryPath" value="./Packages" />
-    <add key="PackagesConfigPath" value="." />
+    <add key="PackagesConfigDirectoryPath" value="." />
     <add key="DefaultPushSource" value="http://www.nuget.org/api/v2/" />
     <add key="verbose" value="true" />
     <add key="ReadOnlyPackageFiles" value="false" />

--- a/src/NuGetForUnity.Tests/Assets/NuGet.config
+++ b/src/NuGetForUnity.Tests/Assets/NuGet.config
@@ -4,15 +4,16 @@
     <add key="NuGet" value="http://www.nuget.org/api/v2/" />
     <add key="V3" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <disabledPackageSources />
   <packageSourceCredentials />
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
   <config>
     <add key="repositoryPath" value="./Packages" />
+    <add key="PackagesConfigPath" value="." />
     <add key="DefaultPushSource" value="http://www.nuget.org/api/v2/" />
     <add key="verbose" value="true" />
-    <add key="PackagesConfigPath" value=".." />
     <add key="ReadOnlyPackageFiles" value="false" />
   </config>
 </configuration>

--- a/src/NuGetForUnity.Tests/Assets/NuGet.config
+++ b/src/NuGetForUnity.Tests/Assets/NuGet.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="NuGet" value="http://www.nuget.org/api/v2/" />
@@ -12,6 +12,7 @@
     <add key="repositoryPath" value="./Packages" />
     <add key="DefaultPushSource" value="http://www.nuget.org/api/v2/" />
     <add key="verbose" value="true" />
+    <add key="PackagesConfigPath" value="Assets" />
     <add key="ReadOnlyPackageFiles" value="false" />
   </config>
 </configuration>

--- a/src/NuGetForUnity.Tests/Assets/NuGet.config
+++ b/src/NuGetForUnity.Tests/Assets/NuGet.config
@@ -12,7 +12,7 @@
     <add key="repositoryPath" value="./Packages" />
     <add key="DefaultPushSource" value="http://www.nuget.org/api/v2/" />
     <add key="verbose" value="true" />
-    <add key="PackagesConfigPath" value="Assets" />
+    <add key="PackagesConfigPath" value=".." />
     <add key="ReadOnlyPackageFiles" value="false" />
   </config>
 </configuration>

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -648,9 +648,6 @@ public class NuGetTests
         packagesConfigFile.Save();
 
         Assert.IsFalse(NugetHelper.IsInstalled(package), "The package IS installed: {0} {1}", package.Id, package.Version);
-
-        var assetsIndex = filepath.LastIndexOf("Assets", StringComparison.Ordinal);
-        filepath = filepath.Substring(assetsIndex);
         NugetPackageAssetPostprocessor.OnPostprocessAllAssets(new[] { filepath }, null, null, null);
 
         Assert.IsTrue(NugetHelper.IsInstalled(package), "The package was NOT installed: {0} {1}", package.Id, package.Version);
@@ -668,9 +665,6 @@ public class NuGetTests
 
         var packagesConfigFile = new PackagesConfigFile();
         packagesConfigFile.Save();
-
-        var assetsIndex = filepath.LastIndexOf("Assets", StringComparison.Ordinal);
-        filepath = filepath.Substring(assetsIndex);
         NugetPackageAssetPostprocessor.OnPostprocessAllAssets(new[] { filepath }, null, null, null);
 
         Assert.IsFalse(NugetHelper.IsInstalled(package), "The package is STILL installed: {0} {1}", package.Id, package.Version);
@@ -691,9 +685,6 @@ public class NuGetTests
         var packagesConfigFile = new PackagesConfigFile();
         packagesConfigFile.AddPackage(packageNew);
         packagesConfigFile.Save();
-
-        var assetsIndex = filepath.LastIndexOf("Assets", StringComparison.Ordinal);
-        filepath = filepath.Substring(assetsIndex);
         NugetPackageAssetPostprocessor.OnPostprocessAllAssets(new[] { filepath }, null, null, null);
 
         Assert.IsFalse(NugetHelper.IsInstalled(packageOld), "The old package version IS STILL installed: {0} {1}", packageOld.Id, packageOld.Version);

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -704,31 +704,16 @@ public class NuGetTests
     [Test]
     [TestCase("Assets", "Assets")]
     [TestCase(".", ".")]
-    [TestCase("", ".")]
+    [TestCase("", "")]
     [TestCase("Assets/../../", "..")]
-    [TestCase("Assets/", "Assets/")]
+    [TestCase("Assets/../../../", "../..")]
+    [TestCase("M:/Test", "M:/Test")]
+    [TestCase("./Assets", "Assets")]
     [TestCase("a/b/c", "a/b/c")]
     [TestCase("../../", "../..")]
     [TestCase("../..", "../..")]
-    [TestCase("Assets/../../../", "../..")]
-    public void GetProjectRelativePathTest(string projectRelativePath, string expected)
-    {
-        // allow running tests on windows and linux
-        expected = expected.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-
-        var path = Path.GetFullPath(Path.Combine(NugetHelper.AbsoluteProjectPath, projectRelativePath));
-        var relativePath = NugetHelper.GetProjectRelativePath(path);
-
-        Assert.That(relativePath, Is.EqualTo(expected));
-    }
-
-    [Test]
-    [TestCase("Assets", "Assets")]
-    [TestCase("Assets/../../", "..")]
-    [TestCase("C:/Test", "C:/Test")]
-    [TestCase("./Assets", "Assets")]
-    [TestCase("C:/Test/", "C:/Test/")]
-    [TestCase("C:/Test/test.txt", "C:/Test/test.txt")]
+    [TestCase("M:/Test/", "M:/Test/")]
+    [TestCase("M:/Test/test.txt", "M:/Test/test.txt")]
     public void GetRelativePathTest(string path, string expected)
     {
         // allow running tests on windows and linux

--- a/src/NuGetForUnity.Tests/Assets/Tests/Resources/NuGet.config
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Resources/NuGet.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
@@ -16,6 +16,7 @@
   </activePackageSource>
   <config>
     <add key="repositoryPath" value="./Packages" />
+    <add key="PackagesConfigPath" value="Assets" />
     <add key="ReadOnlyPackageFiles" value="false" />
   </config>
 </configuration>

--- a/src/NuGetForUnity.Tests/Assets/Tests/Resources/NuGet.config
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Resources/NuGet.config
@@ -16,7 +16,7 @@
   </activePackageSource>
   <config>
     <add key="repositoryPath" value="./Packages" />
-    <add key="PackagesConfigPath" value="." />
+    <add key="PackagesConfigDirectoryPath" value="." />
     <add key="ReadOnlyPackageFiles" value="false" />
   </config>
 </configuration>

--- a/src/NuGetForUnity.Tests/Assets/Tests/Resources/NuGet.config
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Resources/NuGet.config
@@ -16,7 +16,7 @@
   </activePackageSource>
   <config>
     <add key="repositoryPath" value="./Packages" />
-    <add key="PackagesConfigPath" value="Assets" />
+    <add key="PackagesConfigPath" value="." />
     <add key="ReadOnlyPackageFiles" value="false" />
   </config>
 </configuration>

--- a/src/NuGetForUnity.Tests/Assets/packages.config
+++ b/src/NuGetForUnity.Tests/Assets/packages.config
@@ -1,2 +1,2 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages />

--- a/src/NuGetForUnity/Editor/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/NugetConfigFile.cs
@@ -74,30 +74,13 @@ namespace NugetForUnity
         /// </summary>
         public bool ReadOnlyPackageFiles { get; set; }
 
-        public string PackagesConfigPath;
+        public string PackagesConfigPath { get; set; }
 
         public string RelativePackagesConfigPath
         {
-            get => NugetHelper.GetProjectRelativePath(PackagesConfigPath);
+            get => NugetHelper.GetAssetsRelativePath(PackagesConfigPath);
 
-            private set
-            {
-                var tempValue = Environment.ExpandEnvironmentVariables(value);
-                if (tempValue == "Assets" || tempValue == "Assets/" || tempValue == "Assets\\")
-                {
-                    PackagesConfigPath = Application.dataPath;
-                }
-                else if (tempValue.StartsWith("Assets/") || tempValue.StartsWith("Assets\\"))
-                {
-                    PackagesConfigPath = Path.Combine(Application.dataPath, tempValue.Substring("Assets/".Length));
-                }
-                else
-                {
-                    Debug.LogWarning($"Path to packages.config in NuGet.config must be relative to the project root (attempted path: {tempValue}). Setting to default.");
-                    PackagesConfigPath = Application.dataPath;
-                    Save(NugetHelper.NugetConfigFilePath);
-                }
-            }
+            private set => PackagesConfigPath = Path.GetFullPath(Path.Combine(Application.dataPath, value));
         }
 
         /// <summary>
@@ -269,7 +252,7 @@ namespace NugetForUnity
             configFile.PackageSources = new List<INugetPackageSource>();
             configFile.InstallFromCache = true;
             configFile.ReadOnlyPackageFiles = false;
-            configFile.RelativePackagesConfigPath = "Assets";
+            configFile.RelativePackagesConfigPath = ".";
 
             var file = XDocument.Load(filePath);
 
@@ -421,7 +404,7 @@ namespace NugetForUnity
   </activePackageSource>
   <config>
     <add key=""repositoryPath"" value=""./Packages"" />
-    <add key=""PackagesConfigPath"" value=""Assets"" />
+    <add key=""PackagesConfigPath"" value=""."" />
   </config>
 </configuration>";
 

--- a/src/NuGetForUnity/Editor/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/NugetConfigFile.cs
@@ -82,18 +82,21 @@ namespace NugetForUnity
 
             private set
             {
-                PackagesConfigPath = Path.GetFullPath(Environment.ExpandEnvironmentVariables(value));
-
-                var packageConfigRelativePath = NugetHelper.GetProjectRelativePath(PackagesConfigPath);
-
-                // package config path is invalid (not under Assets), set to default
-                if (packageConfigRelativePath == PackagesConfigPath || packageConfigRelativePath == ".")
+                var tempValue = Environment.ExpandEnvironmentVariables(value);
+                if (tempValue == "Assets" || tempValue == "Assets/" || tempValue == "Assets\\")
                 {
-                    Debug.LogError("Path to packages.config in NuGet.config must be relative to the project root. Setting to default.");
                     PackagesConfigPath = Application.dataPath;
                 }
-
-                PackagesConfigPath = PackagesConfigPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                else if (tempValue.StartsWith("Assets/") || tempValue.StartsWith("Assets\\"))
+                {
+                    PackagesConfigPath = Path.Combine(Application.dataPath, tempValue.Substring("Assets/".Length));
+                }
+                else
+                {
+                    Debug.LogWarning($"Path to packages.config in NuGet.config must be relative to the project root (attempted path: {tempValue}). Setting to default.");
+                    PackagesConfigPath = Application.dataPath;
+                    Save(NugetHelper.NugetConfigFilePath);
+                }
             }
         }
 

--- a/src/NuGetForUnity/Editor/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/NugetConfigFile.cs
@@ -28,6 +28,8 @@ namespace NugetForUnity
 
         private const string LockPackagesOnRestoreConfigKey = "LockPackagesOnRestore";
 
+        private const string PackagesConfigDirectoryPathConfigKey = "PackagesConfigDirectoryPath";
+
         /// <summary>
         ///     The incomplete path that is saved.  The path is expanded and made public via the property above.
         /// </summary>
@@ -74,19 +76,21 @@ namespace NugetForUnity
         /// </summary>
         public bool ReadOnlyPackageFiles { get; set; }
 
-        public string PackagesConfigPath { get; set; }
+        /// <summary>
+        ///     Gets or sets absolute path to directory containing packages.config file.
+        /// </summary>
+        public string PackagesConfigDirectoryPath { get; set; }
 
         public string RelativePackagesConfigPath
         {
-            get => NugetHelper.GetAssetsRelativePath(PackagesConfigPath);
-
-            private set => PackagesConfigPath = Path.GetFullPath(Path.Combine(Application.dataPath, value));
+            get => PathHelper.GetRelativePath(Application.dataPath, PackagesConfigDirectoryPath);
+            private set => PackagesConfigDirectoryPath = Path.GetFullPath(Path.Combine(Application.dataPath, value));
         }
 
         /// <summary>
         ///     The path to the packages.config file.
         /// </summary>
-        public string PackagesConfigFilePath => Path.Combine(PackagesConfigPath, PackagesConfigFile.FileName);
+        public string PackagesConfigFilePath => Path.Combine(PackagesConfigDirectoryPath, PackagesConfigFile.FileName);
 
         /// <summary>
         ///     Gets or sets the timeout in seconds used for all web requests to NuGet sources.
@@ -162,7 +166,7 @@ namespace NugetForUnity
             config.Add(addElement);
 
             addElement = new XElement("add");
-            addElement.Add(new XAttribute("key", "PackagesConfigPath"));
+            addElement.Add(new XAttribute("key", PackagesConfigDirectoryPathConfigKey));
             addElement.Add(new XAttribute("value", RelativePackagesConfigPath));
             config.Add(addElement);
 
@@ -375,7 +379,7 @@ namespace NugetForUnity
                     {
                         configFile.LockPackagesOnRestore = bool.Parse(value);
                     }
-                    else if (string.Equals(key, "PackagesConfigPath", StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals(key, PackagesConfigDirectoryPathConfigKey, StringComparison.OrdinalIgnoreCase))
                     {
                         configFile.RelativePackagesConfigPath = value;
                     }
@@ -404,7 +408,7 @@ namespace NugetForUnity
   </activePackageSource>
   <config>
     <add key=""repositoryPath"" value=""./Packages"" />
-    <add key=""PackagesConfigPath"" value=""."" />
+    <add key=""PackagesConfigDirectoryPath"" value=""."" />
   </config>
 </configuration>";
 

--- a/src/NuGetForUnity/Editor/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/NugetConfigFile.cs
@@ -91,7 +91,6 @@ namespace NugetForUnity
                 {
                     Debug.LogError("Path to packages.config in NuGet.config must be relative to the project root. Setting to default.");
                     PackagesConfigPath = Application.dataPath;
-                    Save(NugetHelper.NugetConfigFilePath);
                 }
 
                 PackagesConfigPath = PackagesConfigPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);

--- a/src/NuGetForUnity/Editor/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/NugetConfigFile.cs
@@ -81,14 +81,17 @@ namespace NugetForUnity
         /// </summary>
         public string PackagesConfigDirectoryPath { get; set; }
 
-        public string RelativePackagesConfigPath
+        /// <summary>
+        ///     Gets the relative path to directory containing packages.config file. The path is relative to the folder containing the 'NuGet.config' file.
+        /// </summary>
+        public string RelativePackagesConfigDirectoryPath
         {
             get => PathHelper.GetRelativePath(Application.dataPath, PackagesConfigDirectoryPath);
             private set => PackagesConfigDirectoryPath = Path.GetFullPath(Path.Combine(Application.dataPath, value));
         }
 
         /// <summary>
-        ///     The path to the packages.config file.
+        ///     Gets the path to the packages.config file.
         /// </summary>
         public string PackagesConfigFilePath => Path.Combine(PackagesConfigDirectoryPath, PackagesConfigFile.FileName);
 
@@ -167,7 +170,7 @@ namespace NugetForUnity
 
             addElement = new XElement("add");
             addElement.Add(new XAttribute("key", PackagesConfigDirectoryPathConfigKey));
-            addElement.Add(new XAttribute("value", RelativePackagesConfigPath));
+            addElement.Add(new XAttribute("value", RelativePackagesConfigDirectoryPath));
             config.Add(addElement);
 
             // save the default push source
@@ -256,7 +259,7 @@ namespace NugetForUnity
             configFile.PackageSources = new List<INugetPackageSource>();
             configFile.InstallFromCache = true;
             configFile.ReadOnlyPackageFiles = false;
-            configFile.RelativePackagesConfigPath = ".";
+            configFile.RelativePackagesConfigDirectoryPath = ".";
 
             var file = XDocument.Load(filePath);
 
@@ -381,7 +384,7 @@ namespace NugetForUnity
                     }
                     else if (string.Equals(key, PackagesConfigDirectoryPathConfigKey, StringComparison.OrdinalIgnoreCase))
                     {
-                        configFile.RelativePackagesConfigPath = value;
+                        configFile.RelativePackagesConfigDirectoryPath = value;
                     }
                 }
             }

--- a/src/NuGetForUnity/Editor/NugetHelper.cs
+++ b/src/NuGetForUnity/Editor/NugetHelper.cs
@@ -138,7 +138,7 @@ namespace NugetForUnity
         /// </summary>
         /// <param name="path">The path of witch we calculate the relative path of.</param>
         /// <returns>The path relative to Assets directory, or <c>"."</c> if it is the Assets directory.</returns>
-        public static string GetAssetsRelativePath(string path)
+        internal static string GetAssetsRelativePath(string path)
         {
             return PathHelper.GetRelativePath(Application.dataPath, path);
         }

--- a/src/NuGetForUnity/Editor/NugetHelper.cs
+++ b/src/NuGetForUnity/Editor/NugetHelper.cs
@@ -134,13 +134,13 @@ namespace NugetForUnity
         }
 
         /// <summary>
-        ///     Returns the path relative to project directory, or <c>"."</c> if it is the project directory.
+        ///     Returns the path relative to Assets directory, or <c>"."</c> if it is the Assets directory.
         /// </summary>
         /// <param name="path">The path of witch we calculate the relative path of.</param>
-        /// <returns>The path relative to project directory, or <c>"."</c> if it is the project directory.</returns>
-        public static string GetProjectRelativePath(string path)
+        /// <returns>The path relative to Assets directory, or <c>"."</c> if it is the Assets directory.</returns>
+        public static string GetAssetsRelativePath(string path)
         {
-            return PathHelper.GetRelativePath(AbsoluteProjectPath, path);
+            return PathHelper.GetRelativePath(Application.dataPath, path);
         }
 
         /// <summary>
@@ -1170,7 +1170,7 @@ namespace NugetForUnity
         /// <param name="args">The arguments for the formatted message string.</param>
         public static void LogVerbose(string format, params object[] args)
         {
-            if (NugetConfigFile != null && !NugetConfigFile.Verbose)
+            if (nugetConfigFile != null && !nugetConfigFile.Verbose)
             {
                 return;
             }

--- a/src/NuGetForUnity/Editor/NugetPackageAssetPostprocessor.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageAssetPostprocessor.cs
@@ -175,7 +175,7 @@ namespace NugetForUnity
 
         private static bool AssetIsDllInsideNuGetRepository(string absoluteAssetPath, string absoluteRepositoryPath)
         {
-            return absoluteAssetPath.StartsWith(absoluteRepositoryPath, StringComparison.OrdinalIgnoreCase) &&
+            return absoluteAssetPath.StartsWith(absoluteRepositoryPath, PathHelper.PathComparisonType) &&
                    absoluteAssetPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
                    File.Exists(absoluteAssetPath);
         }
@@ -186,11 +186,6 @@ namespace NugetForUnity
         /// <returns>The absolute path where NuGetForUnity restores NuGet packages, with trailing directory separator.</returns>
         private static string GetNuGetRepositoryPath()
         {
-            if (NugetHelper.NugetConfigFile == null)
-            {
-                NugetHelper.LoadNugetConfigFile();
-            }
-
             return NugetHelper.NugetConfigFile.RepositoryPath + Path.DirectorySeparatorChar;
         }
 

--- a/src/NuGetForUnity/Editor/NugetPackageAssetPostprocessor.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageAssetPostprocessor.cs
@@ -52,7 +52,13 @@ namespace NugetForUnity
             string[] movedAssets,
             string[] movedFromAssetPaths)
         {
-            var packagesConfigFilePath = Path.GetFullPath(NugetHelper.PackagesConfigFilePath);
+            // currently only importedAssets are important for us, so if there are none, we do nothing
+            if (importedAssets.Length == 0)
+            {
+                return;
+            }
+
+            var packagesConfigFilePath = NugetHelper.NugetConfigFile.PackagesConfigFilePath;
             var foundPackagesConfigAsset = importedAssets.Any(
                 importedAsset => Path.GetFullPath(importedAsset).Equals(packagesConfigFilePath, StringComparison.Ordinal));
 

--- a/src/NuGetForUnity/Editor/NugetPreferences.cs
+++ b/src/NuGetForUnity/Editor/NugetPreferences.cs
@@ -1,4 +1,6 @@
-﻿using UnityEditor;
+﻿using System.IO;
+using System.Linq;
+using UnityEditor;
 using UnityEngine;
 
 namespace NugetForUnity
@@ -71,6 +73,34 @@ namespace NugetForUnity
                 preferencesChangedThisFrame = true;
                 NugetHelper.NugetConfigFile.Verbose = verbose;
             }
+
+            EditorGUILayout.BeginHorizontal();
+            {
+                var packagesConfigPath = NugetHelper.NugetConfigFile.RelativePackagesConfigPath;
+                EditorGUILayout.LabelField($"Packages Config path: {packagesConfigPath}");
+                packagesConfigPath = Path.GetFullPath(packagesConfigPath);
+                if (GUILayout.Button("Browse"))
+                {
+                    var newPath = EditorUtility.OpenFolderPanel("Select Folder", packagesConfigPath, "");
+
+                    if (!string.IsNullOrEmpty(newPath) && newPath != packagesConfigPath)
+                    {
+                        var pathCheck = NugetHelper.GetProjectRelativePath(newPath);
+
+                        // make sure the path is within Assets directory
+                        if (!pathCheck.StartsWith("Assets"))
+                        {
+                            Debug.LogError("packages.config path has to be within <project root>/Assets.");
+                        }
+                        else
+                        {
+                            PackagesConfigFile.Move(newPath);
+                            preferencesChangedThisFrame = true;
+                        }
+                    }
+                }
+            }
+            EditorGUILayout.EndHorizontal();
 
             var requestTimeout = EditorGUILayout.IntField(
                 new GUIContent(

--- a/src/NuGetForUnity/Editor/NugetPreferences.cs
+++ b/src/NuGetForUnity/Editor/NugetPreferences.cs
@@ -31,9 +31,7 @@ namespace NugetForUnity
         public NugetPreferences()
             : base("Preferences/NuGet For Unity", SettingsScope.User)
         {
-            var packagesConfigPath = NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath;
-            var pathCheck = NugetHelper.GetAssetsRelativePath(packagesConfigPath);
-            shouldShowPackagesConfigPathWarning = pathCheck.StartsWith("..") || Path.IsPathRooted(pathCheck);
+            shouldShowPackagesConfigPathWarning = IsPathInAssets(NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath);
         }
 
         /// <summary>
@@ -44,6 +42,17 @@ namespace NugetForUnity
         public static SettingsProvider Create()
         {
             return new NugetPreferences();
+        }
+
+        /// <summary>
+        ///     Checks if given path is within Assets folder.
+        /// </summary>
+        /// <param name="path">Path to check.</param>
+        /// <returns>True if path is within Assets folder, false otherwise.</returns>
+        private static bool IsPathInAssets(string path)
+        {
+            var pathCheck = NugetHelper.GetAssetsRelativePath(path);
+            return pathCheck.StartsWith("..") || Path.IsPathRooted(pathCheck);
         }
 
         /// <summary>
@@ -90,10 +99,8 @@ namespace NugetForUnity
 
                     if (!string.IsNullOrEmpty(newPath) && newPath != packagesConfigPath)
                     {
-                        var pathCheck = NugetHelper.GetAssetsRelativePath(newPath);
-
                         // if the path root is different or it is not under Assets folder, we want to show a warning message
-                        shouldShowPackagesConfigPathWarning = pathCheck.StartsWith("..") || Path.IsPathRooted(pathCheck);
+                        shouldShowPackagesConfigPathWarning = IsPathInAssets(newPath);
 
                         PackagesConfigFile.Move(newPath);
                         preferencesChangedThisFrame = true;

--- a/src/NuGetForUnity/Editor/NugetPreferences.cs
+++ b/src/NuGetForUnity/Editor/NugetPreferences.cs
@@ -21,6 +21,11 @@ namespace NugetForUnity
         private static Vector2 scrollPosition;
 
         /// <summary>
+        ///     Indicates if the warning for packages.config file path should be shown in case it is outside of Assets folder.
+        /// </summary>
+        private static bool shouldShowPackagesConfigPathWarning;
+
+        /// <summary>
         ///     Initializes a new instance of the <see cref="NugetPreferences" /> class.
         /// </summary>
         public NugetPreferences()
@@ -71,7 +76,7 @@ namespace NugetForUnity
 
             EditorGUILayout.BeginHorizontal();
             {
-                var packagesConfigPath = NugetHelper.NugetConfigFile.PackagesConfigPath;
+                var packagesConfigPath = NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath;
                 EditorGUILayout.LabelField(
                     new GUIContent($"Packages Config path: {NugetHelper.NugetConfigFile.RelativePackagesConfigPath}", $"Absolute path: {packagesConfigPath}"));
                 if (GUILayout.Button("Browse"))
@@ -82,12 +87,8 @@ namespace NugetForUnity
                     {
                         var pathCheck = NugetHelper.GetAssetsRelativePath(newPath);
 
-                        // if the path root is different or it is not under Assets folder, we issue a warning
-                        if (pathCheck == newPath || pathCheck.StartsWith(".."))
-                        {
-                            Debug.LogWarning(
-                                "Putting packages.config outside of Assets folder disables the functionality of restoring packages if the file is changed on the disk.");
-                        }
+                        // if the path root is different or it is not under Assets folder, we want to show a warning message
+                        shouldShowPackagesConfigPathWarning = pathCheck == newPath || pathCheck.StartsWith("..");
 
                         PackagesConfigFile.Move(newPath);
                         preferencesChangedThisFrame = true;
@@ -95,6 +96,11 @@ namespace NugetForUnity
                 }
             }
             EditorGUILayout.EndHorizontal();
+            if (shouldShowPackagesConfigPathWarning)
+            {
+                EditorGUILayout.HelpBox(
+                    "Putting packages.config outside of Assets folder disables the functionality of restoring packages if the file is changed on the disk.", MessageType.Warning);
+            }
 
             var requestTimeout = EditorGUILayout.IntField(
                 new GUIContent(

--- a/src/NuGetForUnity/Editor/PackagesConfigFile.cs
+++ b/src/NuGetForUnity/Editor/PackagesConfigFile.cs
@@ -225,6 +225,7 @@ namespace NugetForUnity
             var oldFilePath = NugetHelper.NugetConfigFile.PackagesConfigFilePath;
             var oldPath = NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath;
             NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath = newPath;
+            var newFilePath = Path.GetFullPath(Path.Combine(newPath, FileName));
             try
             {
                 if (!File.Exists(oldFilePath))
@@ -236,35 +237,35 @@ namespace NugetForUnity
                     return;
                 }
 
-                var newFilePath = Path.GetFullPath(Path.Combine(newPath, FileName));
-
                 Directory.CreateDirectory(newPath);
 
                 // moving config to the new path
                 File.Move(oldFilePath, newFilePath);
-
-                // manually moving meta file to suppress Unity warning
-                if (File.Exists($"{oldFilePath}.meta"))
-                {
-                    File.Move($"{oldFilePath}.meta", $"{newFilePath}.meta");
-                }
-
-                // if the old path is now an empty directory, delete it
-                if (!Directory.EnumerateFileSystemEntries(oldPath).Any())
-                {
-                    Directory.Delete(oldPath);
-
-                    // also delete its meta file if it exists
-                    if (File.Exists($"{oldPath}.meta"))
-                    {
-                        File.Delete($"{oldPath}.meta");
-                    }
-                }
             }
             catch (Exception e)
             {
+                // usually unauthorized access or IO exception (trying to move to a folder where the same file exists)
                 Debug.LogException(e);
                 NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath = oldPath;
+                return;
+            }
+
+            // manually moving meta file to suppress Unity warning
+            if (File.Exists($"{oldFilePath}.meta"))
+            {
+                File.Move($"{oldFilePath}.meta", $"{newFilePath}.meta");
+            }
+
+            // if the old path is now an empty directory, delete it
+            if (!Directory.EnumerateFileSystemEntries(oldPath).Any())
+            {
+                Directory.Delete(oldPath);
+
+                // also delete its meta file if it exists
+                if (File.Exists($"{oldPath}.meta"))
+                {
+                    File.Delete($"{oldPath}.meta");
+                }
             }
         }
 

--- a/src/NuGetForUnity/Editor/PackagesConfigFile.cs
+++ b/src/NuGetForUnity/Editor/PackagesConfigFile.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using UnityEditor;
 using UnityEngine;
 
 namespace NugetForUnity
@@ -106,8 +107,9 @@ namespace NugetForUnity
         ///     Loads a list of all currently installed packages by reading the packages.config file.
         /// </summary>
         /// <returns>A newly created <see cref="PackagesConfigFile" />.</returns>
-        public static PackagesConfigFile Load(string filePath)
+        public static PackagesConfigFile Load()
         {
+            var filePath = NugetHelper.NugetConfigFile.PackagesConfigFilePath;
             var configFile = new PackagesConfigFile { Packages = new List<PackageConfig>() };
 
             // Create a package.config file, if there isn't already one in the project
@@ -115,7 +117,7 @@ namespace NugetForUnity
             {
                 Debug.LogFormat("No packages.config file found. Creating default at {0}", filePath);
 
-                configFile.Save(filePath);
+                configFile.Save();
             }
 
             var packagesFile = XDocument.Load(filePath);
@@ -141,8 +143,9 @@ namespace NugetForUnity
         ///     Saves the packages.config file and populates it with given installed NugetPackages.
         /// </summary>
         /// <param name="filePath">The file-path to where this packages.config will be saved.</param>
-        public void Save(string filePath)
+        public void Save()
         {
+            var filePath = NugetHelper.NugetConfigFile.PackagesConfigFilePath;
             if (contentIsSameAsInFilePath == filePath)
             {
                 return;
@@ -210,6 +213,50 @@ namespace NugetForUnity
 
             packagesFile.Save(filePath);
             contentIsSameAsInFilePath = filePath;
+        }
+
+        internal static void Move(string newPath)
+        {
+            var oldFilePath = NugetHelper.NugetConfigFile.PackagesConfigFilePath;
+            var oldPath = NugetHelper.NugetConfigFile.PackagesConfigPath;
+            NugetHelper.NugetConfigFile.PackagesConfigPath = newPath;
+            if (!File.Exists(oldFilePath))
+            {
+                Debug.LogFormat("No packages.config file found. Creating default at {0}", newPath);
+                var configFile = new PackagesConfigFile { Packages = new List<PackageConfig>() };
+                configFile.Save();
+                AssetDatabase.Refresh();
+                return;
+            }
+
+            var newFilePath = Path.GetFullPath(Path.Combine(newPath, FileName));
+
+            // creating directory if it doesn't exist
+            if (!Directory.Exists(newPath))
+            {
+                Directory.CreateDirectory(newPath);
+            }
+
+            // moving config to the new path
+            File.Move(oldFilePath, newFilePath);
+
+            // manually moving meta file to suppress Unity warning
+            if (File.Exists(oldFilePath + ".meta"))
+            {
+                File.Move(oldFilePath + ".meta", newFilePath + ".meta");
+            }
+
+            // if the old path is now an empty directory, delete it
+            if (!Directory.EnumerateFileSystemEntries(oldPath).Any())
+            {
+                Directory.Delete(oldPath);
+
+                // also delete its meta file if it exists
+                if (File.Exists(oldPath + ".meta"))
+                {
+                    File.Delete(oldPath + ".meta");
+                }
+            }
         }
 
         private void MarkAsModified()

--- a/src/NuGetForUnity/Editor/PackagesConfigFile.cs
+++ b/src/NuGetForUnity/Editor/PackagesConfigFile.cs
@@ -223,8 +223,8 @@ namespace NugetForUnity
         internal static void Move(string newPath)
         {
             var oldFilePath = NugetHelper.NugetConfigFile.PackagesConfigFilePath;
-            var oldPath = NugetHelper.NugetConfigFile.PackagesConfigPath;
-            NugetHelper.NugetConfigFile.PackagesConfigPath = newPath;
+            var oldPath = NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath;
+            NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath = newPath;
             try
             {
                 if (!File.Exists(oldFilePath))
@@ -264,7 +264,7 @@ namespace NugetForUnity
             catch (Exception e)
             {
                 Debug.LogException(e);
-                NugetHelper.NugetConfigFile.PackagesConfigPath = oldPath;
+                NugetHelper.NugetConfigFile.PackagesConfigDirectoryPath = oldPath;
             }
         }
 

--- a/src/NuGetForUnity/Editor/PathHelper.cs
+++ b/src/NuGetForUnity/Editor/PathHelper.cs
@@ -4,220 +4,223 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using UnityEngine;
 
-/// <summary>
-///     Helper class to handle path operations.
-/// </summary>
-internal static class PathHelper
+namespace NugetForUnity
 {
     /// <summary>
-    ///     The path comparison type to use for the current platform the editor is running on.
+    ///     Helper class to handle path operations.
     /// </summary>
-    internal static readonly StringComparison PathComparisonType =
-        Application.platform == RuntimePlatform.WindowsEditor || Application.platform == RuntimePlatform.OSXEditor ?
-            StringComparison.OrdinalIgnoreCase :
-            StringComparison.Ordinal;
-
-    /// <summary>
-    ///     Create a relative path from one path to another. Paths will be resolved before calculating the difference.
-    ///     Default path comparison for the active platform will be used (OrdinalIgnoreCase for Windows or Mac, Ordinal for Unix).
-    /// </summary>
-    /// <remarks>
-    ///     Should the project upgrade to Unity version that has .NET Standard 2.1, this can be removed and instead we will use:
-    ///     Path.GetRelativePath(relativeTo, path).
-    ///     <see
-    ///         href="https://github.com/dotnet/runtime/blob/4aa77dfb0674fd61e41e574b8cc8ae63146f52c4/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L843" />
-    ///     .
-    /// </remarks>
-    /// <param name="relativeTo">The source path the output should be relative to. This path is always considered to be a directory.</param>
-    /// <param name="path">The destination path.</param>
-    /// <returns>The relative path or <paramref name="path" /> if the paths don't share the same root.</returns>
-    internal static string GetRelativePath(string relativeTo, string path)
+    internal static class PathHelper
     {
-        if (string.IsNullOrEmpty(relativeTo))
+        /// <summary>
+        ///     The path comparison type to use for the current platform the editor is running on.
+        /// </summary>
+        internal static readonly StringComparison PathComparisonType =
+            Application.platform == RuntimePlatform.WindowsEditor || Application.platform == RuntimePlatform.OSXEditor ?
+                StringComparison.OrdinalIgnoreCase :
+                StringComparison.Ordinal;
+
+        /// <summary>
+        ///     Create a relative path from one path to another. Paths will be resolved before calculating the difference.
+        ///     Default path comparison for the active platform will be used (OrdinalIgnoreCase for Windows or Mac, Ordinal for Unix).
+        /// </summary>
+        /// <remarks>
+        ///     Should the project upgrade to Unity version that has .NET Standard 2.1, this can be removed and instead we will use:
+        ///     Path.GetRelativePath(relativeTo, path).
+        ///     <see
+        ///         href="https://github.com/dotnet/runtime/blob/4aa77dfb0674fd61e41e574b8cc8ae63146f52c4/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L843" />
+        ///     .
+        /// </remarks>
+        /// <param name="relativeTo">The source path the output should be relative to. This path is always considered to be a directory.</param>
+        /// <param name="path">The destination path.</param>
+        /// <returns>The relative path or <paramref name="path" /> if the paths don't share the same root.</returns>
+        internal static string GetRelativePath(string relativeTo, string path)
         {
-            throw new ArgumentNullException(nameof(relativeTo));
-        }
-
-        if (string.IsNullOrEmpty(path))
-        {
-            return path;
-        }
-
-        relativeTo = Path.GetFullPath(relativeTo);
-        path = Path.GetFullPath(path);
-
-        // Need to check if the roots are different- if they are we need to return the "to" path.
-        if (!AreRootsEqual(relativeTo, path))
-        {
-            return path;
-        }
-
-        var commonLength = GetCommonPathLength(relativeTo, path, PathComparisonType == StringComparison.OrdinalIgnoreCase);
-
-        // If there is nothing in common they can't share the same root, return the "to" path as is.
-        if (commonLength == 0)
-        {
-            return path;
-        }
-
-        // Trailing separators aren't significant for comparison
-        var relativeToLength = relativeTo.Length;
-        if (EndsInDirectorySeparator(relativeTo))
-        {
-            relativeToLength--;
-        }
-
-        var pathEndsInSeparator = EndsInDirectorySeparator(path);
-        var pathLength = path.Length;
-        if (pathEndsInSeparator)
-        {
-            pathLength--;
-        }
-
-        // If we have effectively the same path, return "."
-        if (relativeToLength == pathLength && commonLength >= relativeToLength)
-        {
-            return ".";
-        }
-
-        // We have the same root, we need to calculate the difference now using the
-        // common Length and Segment count past the length.
-        //
-        // Some examples:
-        //
-        //  C:\Foo C:\Bar L3, S1 -> ..\Bar
-        //  C:\Foo C:\Foo\Bar L6, S0 -> Bar
-        //  C:\Foo\Bar C:\Bar\Bar L3, S2 -> ..\..\Bar\Bar
-        //  C:\Foo\Foo C:\Foo\Bar L7, S1 -> ..\Bar
-        var sb = new StringBuilder();
-        sb.EnsureCapacity(Math.Max(relativeTo.Length, path.Length));
-
-        // Add parent segments for segments past the common on the "from" path
-        if (commonLength < relativeToLength)
-        {
-            sb.Append("..");
-
-            for (var i = commonLength + 1; i < relativeToLength; i++)
+            if (string.IsNullOrEmpty(relativeTo))
             {
-                if (IsDirectorySeparator(relativeTo[i]))
+                throw new ArgumentNullException(nameof(relativeTo));
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            relativeTo = Path.GetFullPath(relativeTo);
+            path = Path.GetFullPath(path);
+
+            // Need to check if the roots are different - if they are we need to return the "to" path.
+            if (!AreRootsEqual(relativeTo, path))
+            {
+                return path;
+            }
+
+            var commonLength = GetCommonPathLength(relativeTo, path, PathComparisonType == StringComparison.OrdinalIgnoreCase);
+
+            // If there is nothing in common they can't share the same root, return the "to" path as is.
+            if (commonLength == 0)
+            {
+                return path;
+            }
+
+            // Trailing separators aren't significant for comparison
+            var relativeToLength = relativeTo.Length;
+            if (EndsInDirectorySeparator(relativeTo))
+            {
+                relativeToLength--;
+            }
+
+            var pathEndsInSeparator = EndsInDirectorySeparator(path);
+            var pathLength = path.Length;
+            if (pathEndsInSeparator)
+            {
+                pathLength--;
+            }
+
+            // If we have effectively the same path, return "."
+            if (relativeToLength == pathLength && commonLength >= relativeToLength)
+            {
+                return ".";
+            }
+
+            // We have the same root, we need to calculate the difference now using the
+            // common Length and Segment count past the length.
+            //
+            // Some examples:
+            //
+            //  C:\Foo C:\Bar L3, S1 -> ..\Bar
+            //  C:\Foo C:\Foo\Bar L6, S0 -> Bar
+            //  C:\Foo\Bar C:\Bar\Bar L3, S2 -> ..\..\Bar\Bar
+            //  C:\Foo\Foo C:\Foo\Bar L7, S1 -> ..\Bar
+            var sb = new StringBuilder();
+            sb.EnsureCapacity(Math.Max(relativeTo.Length, path.Length));
+
+            // Add parent segments for segments past the common on the "from" path
+            if (commonLength < relativeToLength)
+            {
+                sb.Append("..");
+
+                for (var i = commonLength + 1; i < relativeToLength; i++)
                 {
-                    sb.Append(Path.DirectorySeparatorChar);
-                    sb.Append("..");
+                    if (IsDirectorySeparator(relativeTo[i]))
+                    {
+                        sb.Append(Path.DirectorySeparatorChar);
+                        sb.Append("..");
+                    }
                 }
             }
-        }
-        else if (IsDirectorySeparator(path[commonLength]))
-        {
-            // No parent segments and we need to eat the initial separator
-            //  (C:\Foo C:\Foo\Bar case)
-            commonLength++;
-        }
-
-        // Now add the rest of the "to" path, adding back the trailing separator
-        var differenceLength = pathLength - commonLength;
-        if (pathEndsInSeparator)
-        {
-            differenceLength++;
-        }
-
-        if (differenceLength > 0)
-        {
-            if (sb.Length > 0)
+            else if (IsDirectorySeparator(path[commonLength]))
             {
-                sb.Append(Path.DirectorySeparatorChar);
+                // No parent segments and we need to eat the initial separator
+                //  (C:\Foo C:\Foo\Bar case)
+                commonLength++;
             }
 
-            sb.Append(path.Substring(commonLength, differenceLength));
-        }
-
-        return sb.ToString();
-    }
-
-    /// <summary>
-    ///     Get the common path length from the start of the string.
-    /// </summary>
-    private static int GetCommonPathLength(string first, string second, bool ignoreCase)
-    {
-        var commonChars = EqualStartingCharacterCount(first, second, ignoreCase);
-
-        // If nothing matches
-        if (commonChars == 0)
-        {
-            return commonChars;
-        }
-
-        // Or we're a full string and equal length or match to a separator
-        if (commonChars == first.Length && (commonChars == second.Length || IsDirectorySeparator(second[commonChars])))
-        {
-            return commonChars;
-        }
-
-        if (commonChars == second.Length && IsDirectorySeparator(first[commonChars]))
-        {
-            return commonChars;
-        }
-
-        // It's possible we matched somewhere in the middle of a segment e.g. C:\Foodie and C:\Foobar.
-        while (commonChars > 0 && !IsDirectorySeparator(first[commonChars - 1]))
-        {
-            commonChars--;
-        }
-
-        return commonChars;
-    }
-
-    /// <summary>
-    ///     Gets the count of common characters from the left optionally ignoring case
-    /// </summary>
-    private static int EqualStartingCharacterCount(string first, string second, bool ignoreCase)
-    {
-        if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second))
-        {
-            return 0;
-        }
-
-        var commonChars = 0;
-        for (; commonChars < first.Length && commonChars < second.Length; ++commonChars)
-        {
-            if (first[commonChars] == second[commonChars] ||
-                (ignoreCase && char.ToUpperInvariant(first[commonChars]) == char.ToUpperInvariant(second[commonChars])))
+            // Now add the rest of the "to" path, adding back the trailing separator
+            var differenceLength = pathLength - commonLength;
+            if (pathEndsInSeparator)
             {
-                continue;
+                differenceLength++;
             }
 
-            break;
+            if (differenceLength > 0)
+            {
+                if (sb.Length > 0)
+                {
+                    sb.Append(Path.DirectorySeparatorChar);
+                }
+
+                sb.Append(path.Substring(commonLength, differenceLength));
+            }
+
+            return sb.ToString();
         }
 
-        return commonChars;
-    }
+        /// <summary>
+        ///     Get the common path length from the start of the string.
+        /// </summary>
+        private static int GetCommonPathLength(string first, string second, bool ignoreCase)
+        {
+            var commonChars = EqualStartingCharacterCount(first, second, ignoreCase);
 
-    /// <summary>
-    ///     Returns true if the two paths have the same root.
-    /// </summary>
-    private static bool AreRootsEqual(string first, string second)
-    {
-        var firstRoot = Path.GetPathRoot(first);
-        var secondRoot = Path.GetPathRoot(second);
+            // If nothing matches
+            if (commonChars == 0)
+            {
+                return commonChars;
+            }
 
-        return string.Equals(firstRoot, secondRoot, PathComparisonType);
-    }
+            // Or we're a full string and equal length or match to a separator
+            if (commonChars == first.Length && (commonChars == second.Length || IsDirectorySeparator(second[commonChars])))
+            {
+                return commonChars;
+            }
 
-    /// <summary>
-    ///     True if the given character is a directory separator.
-    /// </summary>
-    /// <param name="c">The char to compare.</param>
-    /// <returns>True if is a separator.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsDirectorySeparator(char c)
-    {
-        return c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
-    }
+            if (commonChars == second.Length && IsDirectorySeparator(first[commonChars]))
+            {
+                return commonChars;
+            }
 
-    /// <summary>
-    ///     Returns true if the path ends in a directory separator.
-    /// </summary>
-    private static bool EndsInDirectorySeparator(string path)
-    {
-        return !string.IsNullOrEmpty(path) && IsDirectorySeparator(path[path.Length - 1]);
+            // It's possible we matched somewhere in the middle of a segment e.g. C:\Foodie and C:\Foobar.
+            while (commonChars > 0 && !IsDirectorySeparator(first[commonChars - 1]))
+            {
+                commonChars--;
+            }
+
+            return commonChars;
+        }
+
+        /// <summary>
+        ///     Gets the count of common characters from the left optionally ignoring case
+        /// </summary>
+        private static int EqualStartingCharacterCount(string first, string second, bool ignoreCase)
+        {
+            if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second))
+            {
+                return 0;
+            }
+
+            var commonChars = 0;
+            for (; commonChars < first.Length && commonChars < second.Length; ++commonChars)
+            {
+                if (first[commonChars] == second[commonChars] ||
+                    (ignoreCase && char.ToUpperInvariant(first[commonChars]) == char.ToUpperInvariant(second[commonChars])))
+                {
+                    continue;
+                }
+
+                break;
+            }
+
+            return commonChars;
+        }
+
+        /// <summary>
+        ///     Returns true if the two paths have the same root.
+        /// </summary>
+        private static bool AreRootsEqual(string first, string second)
+        {
+            var firstRoot = Path.GetPathRoot(first);
+            var secondRoot = Path.GetPathRoot(second);
+
+            return string.Equals(firstRoot, secondRoot, PathComparisonType);
+        }
+
+        /// <summary>
+        ///     True if the given character is a directory separator.
+        /// </summary>
+        /// <param name="c">The char to compare.</param>
+        /// <returns>True if is a separator.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsDirectorySeparator(char c)
+        {
+            return c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
+        }
+
+        /// <summary>
+        ///     Returns true if the path ends in a directory separator.
+        /// </summary>
+        private static bool EndsInDirectorySeparator(string path)
+        {
+            return !string.IsNullOrEmpty(path) && IsDirectorySeparator(path[path.Length - 1]);
+        }
     }
 }

--- a/src/NuGetForUnity/Editor/PathHelper.cs
+++ b/src/NuGetForUnity/Editor/PathHelper.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using UnityEngine;
+
+/// <summary>
+///     Helper class to handle path operations.
+/// </summary>
+internal static class PathHelper
+{
+    /// <summary>
+    ///     The path comparison type to use for the current platform the editor is running on.
+    /// </summary>
+    internal static readonly StringComparison PathComparisonType =
+        Application.platform == RuntimePlatform.WindowsEditor || Application.platform == RuntimePlatform.OSXEditor ?
+            StringComparison.OrdinalIgnoreCase :
+            StringComparison.Ordinal;
+
+    /// <summary>
+    ///     Create a relative path from one path to another. Paths will be resolved before calculating the difference.
+    ///     Default path comparison for the active platform will be used (OrdinalIgnoreCase for Windows or Mac, Ordinal for Unix).
+    /// </summary>
+    /// <remarks>
+    ///     Should the project upgrade to Unity version that has .NET Standard 2.1, this can be removed and instead we will use:
+    ///     Path.GetRelativePath(relativeTo, path).
+    ///     <see
+    ///         href="https://github.com/dotnet/runtime/blob/4aa77dfb0674fd61e41e574b8cc8ae63146f52c4/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L843" />
+    ///     .
+    /// </remarks>
+    /// <param name="relativeTo">The source path the output should be relative to. This path is always considered to be a directory.</param>
+    /// <param name="path">The destination path.</param>
+    /// <returns>The relative path or <paramref name="path" /> if the paths don't share the same root.</returns>
+    internal static string GetRelativePath(string relativeTo, string path)
+    {
+        if (string.IsNullOrEmpty(relativeTo))
+        {
+            throw new ArgumentNullException(nameof(relativeTo));
+        }
+
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        relativeTo = Path.GetFullPath(relativeTo);
+        path = Path.GetFullPath(path);
+
+        // Need to check if the roots are different- if they are we need to return the "to" path.
+        if (!AreRootsEqual(relativeTo, path))
+        {
+            return path;
+        }
+
+        var commonLength = GetCommonPathLength(relativeTo, path, PathComparisonType == StringComparison.OrdinalIgnoreCase);
+
+        // If there is nothing in common they can't share the same root, return the "to" path as is.
+        if (commonLength == 0)
+        {
+            return path;
+        }
+
+        // Trailing separators aren't significant for comparison
+        var relativeToLength = relativeTo.Length;
+        if (EndsInDirectorySeparator(relativeTo))
+        {
+            relativeToLength--;
+        }
+
+        var pathEndsInSeparator = EndsInDirectorySeparator(path);
+        var pathLength = path.Length;
+        if (pathEndsInSeparator)
+        {
+            pathLength--;
+        }
+
+        // If we have effectively the same path, return "."
+        if (relativeToLength == pathLength && commonLength >= relativeToLength)
+        {
+            return ".";
+        }
+
+        // We have the same root, we need to calculate the difference now using the
+        // common Length and Segment count past the length.
+        //
+        // Some examples:
+        //
+        //  C:\Foo C:\Bar L3, S1 -> ..\Bar
+        //  C:\Foo C:\Foo\Bar L6, S0 -> Bar
+        //  C:\Foo\Bar C:\Bar\Bar L3, S2 -> ..\..\Bar\Bar
+        //  C:\Foo\Foo C:\Foo\Bar L7, S1 -> ..\Bar
+        var sb = new StringBuilder();
+        sb.EnsureCapacity(Math.Max(relativeTo.Length, path.Length));
+
+        // Add parent segments for segments past the common on the "from" path
+        if (commonLength < relativeToLength)
+        {
+            sb.Append("..");
+
+            for (var i = commonLength + 1; i < relativeToLength; i++)
+            {
+                if (IsDirectorySeparator(relativeTo[i]))
+                {
+                    sb.Append(Path.DirectorySeparatorChar);
+                    sb.Append("..");
+                }
+            }
+        }
+        else if (IsDirectorySeparator(path[commonLength]))
+        {
+            // No parent segments and we need to eat the initial separator
+            //  (C:\Foo C:\Foo\Bar case)
+            commonLength++;
+        }
+
+        // Now add the rest of the "to" path, adding back the trailing separator
+        var differenceLength = pathLength - commonLength;
+        if (pathEndsInSeparator)
+        {
+            differenceLength++;
+        }
+
+        if (differenceLength > 0)
+        {
+            if (sb.Length > 0)
+            {
+                sb.Append(Path.DirectorySeparatorChar);
+            }
+
+            sb.Append(path.Substring(commonLength, differenceLength));
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    ///     Get the common path length from the start of the string.
+    /// </summary>
+    private static int GetCommonPathLength(string first, string second, bool ignoreCase)
+    {
+        var commonChars = EqualStartingCharacterCount(first, second, ignoreCase);
+
+        // If nothing matches
+        if (commonChars == 0)
+        {
+            return commonChars;
+        }
+
+        // Or we're a full string and equal length or match to a separator
+        if (commonChars == first.Length && (commonChars == second.Length || IsDirectorySeparator(second[commonChars])))
+        {
+            return commonChars;
+        }
+
+        if (commonChars == second.Length && IsDirectorySeparator(first[commonChars]))
+        {
+            return commonChars;
+        }
+
+        // It's possible we matched somewhere in the middle of a segment e.g. C:\Foodie and C:\Foobar.
+        while (commonChars > 0 && !IsDirectorySeparator(first[commonChars - 1]))
+        {
+            commonChars--;
+        }
+
+        return commonChars;
+    }
+
+    /// <summary>
+    ///     Gets the count of common characters from the left optionally ignoring case
+    /// </summary>
+    private static int EqualStartingCharacterCount(string first, string second, bool ignoreCase)
+    {
+        if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second))
+        {
+            return 0;
+        }
+
+        var commonChars = 0;
+        for (; commonChars < first.Length && commonChars < second.Length; ++commonChars)
+        {
+            if (first[commonChars] == second[commonChars] ||
+                (ignoreCase && char.ToUpperInvariant(first[commonChars]) == char.ToUpperInvariant(second[commonChars])))
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        return commonChars;
+    }
+
+    /// <summary>
+    ///     Returns true if the two paths have the same root.
+    /// </summary>
+    private static bool AreRootsEqual(string first, string second)
+    {
+        var firstRoot = Path.GetPathRoot(first);
+        var secondRoot = Path.GetPathRoot(second);
+
+        return string.Equals(firstRoot, secondRoot, PathComparisonType);
+    }
+
+    /// <summary>
+    ///     True if the given character is a directory separator.
+    /// </summary>
+    /// <param name="c">The char to compare.</param>
+    /// <returns>True if is a separator.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsDirectorySeparator(char c)
+    {
+        return c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
+    }
+
+    /// <summary>
+    ///     Returns true if the path ends in a directory separator.
+    /// </summary>
+    private static bool EndsInDirectorySeparator(string path)
+    {
+        return !string.IsNullOrEmpty(path) && IsDirectorySeparator(path[path.Length - 1]);
+    }
+}

--- a/src/NuGetForUnity/Editor/PathHelper.cs.meta
+++ b/src/NuGetForUnity/Editor/PathHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d0f357dc817cff428024bc195921e57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/NuGetForUnity/Editor/UnityPreImportedLibraryResolver.cs
+++ b/src/NuGetForUnity/Editor/UnityPreImportedLibraryResolver.cs
@@ -28,11 +28,6 @@ namespace NugetForUnity
 
             // Find all the assemblies already installed by NuGetForUnity
             var alreadyInstalledDllFileNames = new HashSet<string>();
-            if (NugetHelper.NugetConfigFile == null)
-            {
-                NugetHelper.LoadNugetConfigFile();
-            }
-
             if (Directory.Exists(NugetHelper.NugetConfigFile.RepositoryPath))
             {
                 alreadyInstalledDllFileNames = new HashSet<string>(


### PR DESCRIPTION
Minor changes in order to make `packages.config` path configurable. We don't allow for the path to be outside of `Assets` folder since we still need `OnPostprocessAllAssets` to be triggered if this file is changed.