### PR TITLE
Package version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ After several seconds (it can take some time to query the server for packages), 
 
 The **Online** tab shows the packages available on the NuGet server.
 
-Enable **Show All Versions** to list all old versions of a package (currently only works with local nuget feeds).
-Disable **Show All Versions** to only show the latest version of a package.
-
 Enable **Show Prerelease** to list prerelease versions of packages (alpha, beta, release candidate, etc).
 Disable **Show Prerelease** to only show stable releases.
 

--- a/src/NuGetForUnity/Editor/CredentialProviderHelper.cs
+++ b/src/NuGetForUnity/Editor/CredentialProviderHelper.cs
@@ -294,8 +294,11 @@ internal static class CredentialProviderHelper
     [Serializable]
     private struct CredentialProviderResponse
     {
+        // Ignore Spelling: Username
+#pragma warning disable CS0649 // Field is assigned on serialization
         public string Username;
 
         public string Password;
+#pragma warning restore CS0649 // Field is assigned on serialization
     }
 }

--- a/src/NuGetForUnity/Editor/INugetPackageIdentifier.cs
+++ b/src/NuGetForUnity/Editor/INugetPackageIdentifier.cs
@@ -34,9 +34,9 @@ namespace NugetForUnity
         bool IsPrerelease { get; }
 
         /// <summary>
-        ///     Gets the typed version number of the NuGet package.
+        ///     Gets or sets the typed version number of the NuGet package.
         /// </summary>
-        NugetPackageVersion PackageVersion { get; }
+        NugetPackageVersion PackageVersion { get; set; }
 
         /// <summary>
         ///     Gets the name of the '.nupkg' file that contains the whole package content as a ZIP.

--- a/src/NuGetForUnity/Editor/INugetPackageSource.cs
+++ b/src/NuGetForUnity/Editor/INugetPackageSource.cs
@@ -61,9 +61,9 @@ namespace NugetForUnity
         List<INugetPackage> FindPackagesById(INugetPackageIdentifier package);
 
         /// <summary>
-        ///     Gets a NugetPackage from the NuGet server that matches (or is in range of) the <see cref="NugetPackageIdentifier" /> given.
+        ///     Gets a NugetPackage from the NuGet server that matches (or is in range of) the <see cref="INugetPackageIdentifier" /> given.
         /// </summary>
-        /// <param name="package">The <see cref="NugetPackageIdentifier" /> containing the ID and Version of the package to get.</param>
+        /// <param name="package">The <see cref="INugetPackageIdentifier" /> containing the ID and Version of the package to get.</param>
         /// <returns>The retrieved package, if there is one.  Null if no matching package was found.</returns>
         INugetPackage GetSpecificPackage(INugetPackageIdentifier package);
 
@@ -72,14 +72,12 @@ namespace NugetForUnity
         /// </summary>
         /// <param name="packages">The list of packages to use to find updates.</param>
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
-        /// <param name="includeAllVersions">True to include older versions that are not the latest version.</param>
         /// <param name="targetFrameworks">The specific frameworks to target?.</param>
         /// <param name="versionConstraints">The version constraints?.</param>
         /// <returns>A list of all updates available.</returns>
         List<INugetPackage> GetUpdates(
             IEnumerable<INugetPackage> packages,
             bool includePrerelease = false,
-            bool includeAllVersions = false,
             string targetFrameworks = "",
             string versionConstraints = "");
 
@@ -88,7 +86,6 @@ namespace NugetForUnity
         ///     This allows searching for partial IDs or even the empty string (the default) to list ALL packages.
         /// </summary>
         /// <param name="searchTerm">The search term to use to filter packages. Defaults to the empty string.</param>
-        /// <param name="includeAllVersions">True to include older versions that are not the latest version.</param>
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
         /// <param name="numberToGet">The number of packages to fetch.</param>
         /// <param name="numberToSkip">The number of packages to skip before fetching.</param>
@@ -96,7 +93,6 @@ namespace NugetForUnity
         /// <returns>The list of available packages.</returns>
         Task<List<INugetPackage>> Search(
             string searchTerm = "",
-            bool includeAllVersions = false,
             bool includePrerelease = false,
             int numberToGet = 15,
             int numberToSkip = 0,

--- a/src/NuGetForUnity/Editor/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/NugetApiClientV3.cs
@@ -400,6 +400,8 @@ namespace NugetForUnity
             }
         }
 
+#pragma warning disable CS0649 // Field is assigned on serialize
+
         [Serializable]
         [SuppressMessage(
             "StyleCop.CSharp.NamingRules",
@@ -798,5 +800,6 @@ namespace NugetForUnity
             /// </summary>
             public string version;
         }
+#pragma warning restore CS0649 // Field is assigned on serialize
     }
 }

--- a/src/NuGetForUnity/Editor/NugetHelper.cs
+++ b/src/NuGetForUnity/Editor/NugetHelper.cs
@@ -943,6 +943,7 @@ namespace NugetForUnity
                     {
                         PackagesConfigFile.SetManuallyInstalledFlag(rootPackage);
                     }
+
                     PackagesConfigFile.Save();
                 }
             }
@@ -979,7 +980,6 @@ namespace NugetForUnity
         ///     NOTE: See the functions and parameters defined here: https://www.nuget.org/api/v2/$metadata.
         /// </summary>
         /// <param name="searchTerm">The search term to use to filter packages. Defaults to the empty string.</param>
-        /// <param name="includeAllVersions">True to include older versions that are not the latest version.</param>
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
         /// <param name="numberToGet">The number of packages to fetch.</param>
         /// <param name="numberToSkip">The number of packages to skip before fetching.</param>
@@ -987,13 +987,12 @@ namespace NugetForUnity
         /// <returns>The list of available packages.</returns>
         public static Task<List<INugetPackage>> Search(
             string searchTerm = "",
-            bool includeAllVersions = false,
             bool includePrerelease = false,
             int numberToGet = 15,
             int numberToSkip = 0,
             CancellationToken cancellationToken = default)
         {
-            return activePackageSource.Search(searchTerm, includeAllVersions, includePrerelease, numberToGet, numberToSkip, cancellationToken);
+            return activePackageSource.Search(searchTerm, includePrerelease, numberToGet, numberToSkip, cancellationToken);
         }
 
         /// <summary>
@@ -1001,18 +1000,16 @@ namespace NugetForUnity
         /// </summary>
         /// <param name="packagesToUpdate">The list of currently installed packages.</param>
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
-        /// <param name="includeAllVersions">True to include older versions that are not the latest version.</param>
         /// <param name="targetFrameworks">The specific frameworks to target?.</param>
         /// <param name="versionConstraints">The version constraints?.</param>
         /// <returns>A list of all updates available.</returns>
         public static List<INugetPackage> GetUpdates(
             IEnumerable<INugetPackage> packagesToUpdate,
             bool includePrerelease = false,
-            bool includeAllVersions = false,
             string targetFrameworks = "",
             string versionConstraints = "")
         {
-            return activePackageSource.GetUpdates(packagesToUpdate, includePrerelease, includeAllVersions, targetFrameworks, versionConstraints);
+            return activePackageSource.GetUpdates(packagesToUpdate, includePrerelease, targetFrameworks, versionConstraints);
         }
 
         /// <summary>

--- a/src/NuGetForUnity/Editor/NugetPackageIdentifier.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageIdentifier.cs
@@ -35,7 +35,7 @@ namespace NugetForUnity
 
         /// <inheritdoc />
         [field: SerializeField]
-        public NugetPackageVersion PackageVersion { get; internal set; }
+        public NugetPackageVersion PackageVersion { get; set; }
 
         /// <inheritdoc />
         [field: SerializeField]

--- a/src/NuGetForUnity/Editor/NugetPackageSourceCombined.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageSourceCombined.cs
@@ -160,7 +160,6 @@ namespace NugetForUnity
         public List<INugetPackage> GetUpdates(
             IEnumerable<INugetPackage> packages,
             bool includePrerelease = false,
-            bool includeAllVersions = false,
             string targetFrameworks = "",
             string versionConstraints = "")
         {
@@ -173,12 +172,11 @@ namespace NugetForUnity
 
             if (activeSourcesCount == 1)
             {
-                return packageSources.First(source => source.IsEnabled)
-                    .GetUpdates(packages, includePrerelease, includeAllVersions, targetFrameworks, versionConstraints);
+                return packageSources.First(source => source.IsEnabled).GetUpdates(packages, includePrerelease, targetFrameworks, versionConstraints);
             }
 
             return packageSources.Where(source => source.IsEnabled)
-                .SelectMany(source => source.GetUpdates(packages, includePrerelease, includeAllVersions, targetFrameworks, versionConstraints))
+                .SelectMany(source => source.GetUpdates(packages, includePrerelease, targetFrameworks, versionConstraints))
                 .Distinct()
                 .ToList();
         }
@@ -186,7 +184,6 @@ namespace NugetForUnity
         /// <inheritdoc />
         public Task<List<INugetPackage>> Search(
             string searchTerm = "",
-            bool includeAllVersions = false,
             bool includePrerelease = false,
             int numberToGet = 15,
             int numberToSkip = 0,
@@ -202,10 +199,10 @@ namespace NugetForUnity
             if (activeSourcesCount == 1)
             {
                 return packageSources.First(source => source.IsEnabled)
-                    .Search(searchTerm, includeAllVersions, includePrerelease, numberToGet, numberToSkip, cancellationToken);
+                    .Search(searchTerm, includePrerelease, numberToGet, numberToSkip, cancellationToken);
             }
 
-            return SearchMultiple(searchTerm, includeAllVersions, includePrerelease, numberToGet, numberToSkip, cancellationToken);
+            return SearchMultiple(searchTerm, includePrerelease, numberToGet, numberToSkip, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -223,7 +220,6 @@ namespace NugetForUnity
 
         private async Task<List<INugetPackage>> SearchMultiple(
             string searchTerm = "",
-            bool includeAllVersions = false,
             bool includePrerelease = false,
             int numberToGet = 15,
             int numberToSkip = 0,
@@ -231,8 +227,7 @@ namespace NugetForUnity
         {
             var results = await Task.WhenAll(
                 packageSources.Where(source => source.IsEnabled)
-                    .Select(
-                        source => source.Search(searchTerm, includeAllVersions, includePrerelease, numberToGet, numberToSkip, cancellationToken)));
+                    .Select(source => source.Search(searchTerm, includePrerelease, numberToGet, numberToSkip, cancellationToken)));
             return results.SelectMany(result => result).Distinct().ToList();
         }
     }

--- a/src/NuGetForUnity/Editor/NugetPackageSourceLocal.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageSourceLocal.cs
@@ -136,24 +136,22 @@ namespace NugetForUnity
         /// <inheritdoc />
         public Task<List<INugetPackage>> Search(
             string searchTerm = "",
-            bool includeAllVersions = false,
             bool includePrerelease = false,
             int numberToGet = 15,
             int numberToSkip = 0,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(GetLocalPackages($"*{searchTerm}*", includeAllVersions, includePrerelease, numberToSkip));
+            return Task.FromResult(GetLocalPackages($"*{searchTerm}*", false, includePrerelease, numberToSkip));
         }
 
         /// <inheritdoc />
         public List<INugetPackage> GetUpdates(
             IEnumerable<INugetPackage> packages,
             bool includePrerelease = false,
-            bool includeAllVersions = false,
             string targetFrameworks = "",
             string versionConstraints = "")
         {
-            return GetLocalUpdates(packages, includePrerelease, includeAllVersions);
+            return GetLocalUpdates(packages, includePrerelease);
         }
 
         /// <inheritdoc />
@@ -198,13 +196,13 @@ namespace NugetForUnity
         ///     Gets a list of all available packages from a local source (not a web server) that match the given filters.
         /// </summary>
         /// <param name="searchTerm">The search term to use to filter packages. Defaults to the empty string.</param>
-        /// <param name="includeAllVersions">True to include older versions that are not the latest version.</param>
+        /// <param name="flattenAllVersions">True to include older versions that are not the latest version.</param>
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
         /// <param name="numberToSkip">The number of packages to skip before fetching.</param>
         /// <returns>The list of available packages.</returns>
         private List<INugetPackage> GetLocalPackages(
             string searchTerm = "",
-            bool includeAllVersions = false,
+            bool flattenAllVersions = false,
             bool includePrerelease = false,
             int numberToSkip = 0)
         {
@@ -242,9 +240,9 @@ namespace NugetForUnity
                         continue;
                     }
 
-                    if (includeAllVersions)
+                    if (flattenAllVersions)
                     {
-                        // if all versions are being included, simply add it and move on
+                        // to flatten all versions we simply add it and move on
                         localPackages.Add(package);
                         continue;
                     }
@@ -286,17 +284,13 @@ namespace NugetForUnity
         /// </summary>
         /// <param name="packages">The list of packages to use to find updates.</param>
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
-        /// <param name="includeAllVersions">True to include older versions that are not the latest version.</param>
         /// <returns>A list of all updates available.</returns>
-        private List<INugetPackage> GetLocalUpdates(
-            IEnumerable<INugetPackage> packages,
-            bool includePrerelease = false,
-            bool includeAllVersions = false)
+        private List<INugetPackage> GetLocalUpdates(IEnumerable<INugetPackage> packages, bool includePrerelease = false)
         {
             var updates = new List<INugetPackage>();
             foreach (var installedPackage in packages)
             {
-                var availablePackages = GetLocalPackages($"{installedPackage.Id}*", includeAllVersions, includePrerelease);
+                var availablePackages = GetLocalPackages($"{installedPackage.Id}*", false, includePrerelease);
                 foreach (var availablePackage in availablePackages)
                 {
                     if (installedPackage.Id == availablePackage.Id)

--- a/src/NuGetForUnity/Editor/NugetPackageSourceV3.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageSourceV3.cs
@@ -149,7 +149,6 @@ namespace NugetForUnity
         public List<INugetPackage> GetUpdates(
             IEnumerable<INugetPackage> packages,
             bool includePrerelease = false,
-            bool includeAllVersions = false,
             string targetFrameworks = "",
             string versionConstraints = "")
         {
@@ -192,7 +191,6 @@ namespace NugetForUnity
         /// <inheritdoc />
         public Task<List<INugetPackage>> Search(
             string searchTerm = "",
-            bool includeAllVersions = false,
             bool includePrerelease = false,
             int numberToGet = 15,
             int numberToSkip = 0,

--- a/src/NuGetForUnity/Editor/NugetWindow.cs
+++ b/src/NuGetForUnity/Editor/NugetWindow.cs
@@ -114,16 +114,6 @@ namespace NugetForUnity
         [SerializeField]
         private List<SerializableNugetPackage> serializableUpdatePackages;
 
-        /// <summary>
-        ///     True to show all old package versions.  False to only show the latest version.
-        /// </summary>
-        private bool showAllOnlineVersions;
-
-        /// <summary>
-        ///     True to show all old package versions.  False to only show the latest version.
-        /// </summary>
-        private bool showAllUpdateVersions;
-
         private bool showImplicitlyInstalled;
 
         /// <summary>
@@ -439,7 +429,7 @@ namespace NugetForUnity
             var searchTerm = onlineSearchTerm != "Search" ? onlineSearchTerm : string.Empty;
 
             // we just block the main thread
-            availablePackages = Task.Run(() => NugetHelper.Search(searchTerm, showAllOnlineVersions, showOnlinePrerelease, numberToGet, numberToSkip))
+            availablePackages = Task.Run(() => NugetHelper.Search(searchTerm, showOnlinePrerelease, numberToGet, numberToSkip))
                 .GetAwaiter()
                 .GetResult();
             NugetHelper.LogVerbose(
@@ -461,7 +451,7 @@ namespace NugetForUnity
         private void UpdateUpdatePackages()
         {
             // get any available updates for the installed packages
-            updatePackages = NugetHelper.GetUpdates(NugetHelper.InstalledPackages, showPrereleaseUpdates, showAllUpdateVersions);
+            updatePackages = NugetHelper.GetUpdates(NugetHelper.InstalledPackages, showPrereleaseUpdates);
         }
 
         /// <summary>
@@ -653,7 +643,7 @@ namespace NugetForUnity
                 DrawPackages(installedPackages.TakeWhile(package => package.IsManuallyInstalled), true);
 
                 var rectangle = EditorGUILayout.GetControlRect(true, 20f, headerStyle);
-                EditorGUI.LabelField(rectangle, "", headerStyle);
+                EditorGUI.LabelField(rectangle, string.Empty, headerStyle);
 
                 showImplicitlyInstalled = EditorGUI.Foldout(
                     rectangle,
@@ -706,7 +696,6 @@ namespace NugetForUnity
                     Task.Run(
                             () => NugetHelper.Search(
                                 onlineSearchTerm != "Search" ? onlineSearchTerm : string.Empty,
-                                showAllOnlineVersions,
                                 showOnlinePrerelease,
                                 numberToGet,
                                 numberToSkip))
@@ -747,23 +736,17 @@ namespace NugetForUnity
             {
                 EditorGUILayout.BeginHorizontal();
                 {
-                    var showAllVersionsTemp = EditorGUILayout.Toggle("Show All Versions", showAllOnlineVersions);
-                    if (showAllVersionsTemp != showAllOnlineVersions)
+                    var showPrereleaseTemp = EditorGUILayout.Toggle("Show Prerelease", showOnlinePrerelease);
+                    if (showPrereleaseTemp != showOnlinePrerelease)
                     {
-                        showAllOnlineVersions = showAllVersionsTemp;
+                        showOnlinePrerelease = showPrereleaseTemp;
                         UpdateOnlinePackages();
                     }
 
                     DrawMandatoryButtons();
                 }
-                EditorGUILayout.EndHorizontal();
 
-                var showPrereleaseTemp = EditorGUILayout.Toggle("Show Prerelease", showOnlinePrerelease);
-                if (showPrereleaseTemp != showOnlinePrerelease)
-                {
-                    showOnlinePrerelease = showPrereleaseTemp;
-                    UpdateOnlinePackages();
-                }
+                EditorGUILayout.EndHorizontal();
 
                 var enterPressed = Event.current.Equals(Event.KeyboardEvent("return"));
 
@@ -855,10 +838,10 @@ namespace NugetForUnity
             {
                 EditorGUILayout.BeginHorizontal();
                 {
-                    var showAllVersionsTemp = EditorGUILayout.Toggle("Show All Versions", showAllUpdateVersions);
-                    if (showAllVersionsTemp != showAllUpdateVersions)
+                    var showPrereleaseTemp = EditorGUILayout.Toggle("Show Prerelease", showPrereleaseUpdates);
+                    if (showPrereleaseTemp != showPrereleaseUpdates)
                     {
-                        showAllUpdateVersions = showAllVersionsTemp;
+                        showPrereleaseUpdates = showPrereleaseTemp;
                         UpdateUpdatePackages();
                     }
 
@@ -884,14 +867,8 @@ namespace NugetForUnity
 
                     DrawMandatoryButtons();
                 }
-                EditorGUILayout.EndHorizontal();
 
-                var showPrereleaseTemp = EditorGUILayout.Toggle("Show Prerelease", showPrereleaseUpdates);
-                if (showPrereleaseTemp != showPrereleaseUpdates)
-                {
-                    showPrereleaseUpdates = showPrereleaseTemp;
-                    UpdateUpdatePackages();
-                }
+                EditorGUILayout.EndHorizontal();
 
                 EditorGUILayout.BeginHorizontal();
                 {

--- a/src/NuGetForUnity/Editor/NugetWindow.cs
+++ b/src/NuGetForUnity/Editor/NugetWindow.cs
@@ -57,6 +57,11 @@ namespace NugetForUnity
         private readonly string[] tabTitles = { "Online", "Installed", "Updates" };
 
         /// <summary>
+        ///     For each package this contains the currently selected version / the state of the version drop-down.
+        /// </summary>
+        private readonly Dictionary<string, VersionDropdownData> versionDropdownDataPerPackage = new Dictionary<string, VersionDropdownData>();
+
+        /// <summary>
         ///     The list of NugetPackages available to install.
         /// </summary>
         private List<INugetPackage> availablePackages = new List<INugetPackage>();
@@ -343,8 +348,7 @@ namespace NugetForUnity
                     continue;
                 }
 
-                unitypackageDownloadUrl = release.assets
-                    .Find(asset => asset.name.EndsWith(".unitypackage", StringComparison.OrdinalIgnoreCase))
+                unitypackageDownloadUrl = release.assets.Find(asset => asset.name.EndsWith(".unitypackage", StringComparison.OrdinalIgnoreCase))
                     ?.browser_download_url;
                 return release.tag_name.TrimStart('v');
             }
@@ -436,7 +440,8 @@ namespace NugetForUnity
 
             // we just block the main thread
             availablePackages = Task.Run(() => NugetHelper.Search(searchTerm, showAllOnlineVersions, showOnlinePrerelease, numberToGet, numberToSkip))
-                .GetAwaiter().GetResult();
+                .GetAwaiter()
+                .GetResult();
             NugetHelper.LogVerbose(
                 "Searching '{0}' in all active package sources returned: {1} packages after {2} ms",
                 searchTerm,
@@ -514,6 +519,12 @@ namespace NugetForUnity
         {
             selectedPackages.Clear();
             openCloneWindows.Clear();
+            foreach (var dropdownData in versionDropdownDataPerPackage.Values)
+            {
+                // reset to latest package version else the update tab will show the same version as the installed tab
+                dropdownData.SelectedIndex = 0;
+            }
+
             ResetScrollPosition();
         }
 
@@ -692,13 +703,15 @@ namespace NugetForUnity
             {
                 numberToSkip += numberToGet;
                 availablePackages.AddRange(
-                 Task.Run(() => NugetHelper.Search(
-                            onlineSearchTerm != "Search" ? onlineSearchTerm : string.Empty,
-                            showAllOnlineVersions,
-                            showOnlinePrerelease,
-                            numberToGet,
-                            numberToSkip))
-                        .GetAwaiter().GetResult());
+                    Task.Run(
+                            () => NugetHelper.Search(
+                                onlineSearchTerm != "Search" ? onlineSearchTerm : string.Empty,
+                                showAllOnlineVersions,
+                                showOnlinePrerelease,
+                                numberToGet,
+                                numberToSkip))
+                        .GetAwaiter()
+                        .GetResult());
             }
 
             EditorGUILayout.EndVertical();
@@ -1012,7 +1025,35 @@ namespace NugetForUnity
                     GUILayout.Label($"Current Version {installed.PackageVersion.FullVersion}");
                 }
 
-                GUILayout.Label($"Version {package.PackageVersion.FullVersion}");
+                if (package.Versions == null || package.Versions.Count <= 1)
+                {
+                    GUILayout.Label($"Version {package.PackageVersion.FullVersion}");
+                }
+                else
+                {
+                    if (!versionDropdownDataPerPackage.TryGetValue(package.Id, out var versionDropdownData))
+                    {
+                        EditorStyles.popup.CalcMinMaxWidth(
+                            new GUIContent(
+                                package.Versions.Select(version => version.FullVersion).OrderByDescending(version => version.Length).First()),
+                            out var minWidth,
+                            out var maxWidth);
+                        versionDropdownData = new VersionDropdownData
+                        {
+                            SortedVersions = package.Versions.OrderByDescending(version => version).ToList(), CalculatedMaxWith = maxWidth + 5,
+                        };
+                        versionDropdownData.DropdownOptions = versionDropdownData.SortedVersions.Select(version => version.FullVersion).ToArray();
+                        versionDropdownData.SelectedIndex = versionDropdownData.SortedVersions.IndexOf(package.PackageVersion);
+                        versionDropdownDataPerPackage.Add(package.Id, versionDropdownData);
+                    }
+
+                    GUILayout.Label("Version");
+                    versionDropdownData.SelectedIndex = EditorGUILayout.Popup(
+                        versionDropdownData.SelectedIndex,
+                        versionDropdownData.DropdownOptions,
+                        GUILayout.Width(versionDropdownData.CalculatedMaxWith));
+                    package.PackageVersion = versionDropdownData.SortedVersions[versionDropdownData.SelectedIndex];
+                }
 
                 if (installed != null)
                 {
@@ -1400,7 +1441,21 @@ namespace NugetForUnity
             }
         }
 
+        private sealed class VersionDropdownData
+        {
+            public int SelectedIndex { get; set; }
+
+            public List<NugetPackageVersion> SortedVersions { get; set; }
+
+            public float CalculatedMaxWith { get; set; }
+
+            public string[] DropdownOptions { get; set; }
+        }
+
 #pragma warning disable 0649
+#pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning disable SA1401 // Fields should be private
+#pragma warning disable SA1310 // Field names should not contain underscore
 
         [Serializable]
         private sealed class GitHubReleaseApiRequestList
@@ -1424,6 +1479,9 @@ namespace NugetForUnity
             public string name;
         }
 
+#pragma warning restore SA1310 // Field names should not contain underscore
+#pragma warning restore SA1401 // Fields should be private
+#pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning restore 0649
     }
 }


### PR DESCRIPTION
Allow selection what version of a package should be installed.
![image](https://github.com/GlitchEnzo/NuGetForUnity/assets/53140583/ec26aab1-c076-467a-b8c0-3521b09d21b5)

This also removes the "Show all Versions" checkbox because it has no actual usage.
- Packages fetched using Local or V3 API package source support the `Versions` list so the version can be selected using the drop down.
- Packages fetched using V2 API never supported these feature (at least not the nuget.org V2 API)

fixes #409