### PR TITLE
Optimizing installation duration

### DIFF
--- a/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
@@ -217,7 +217,7 @@ namespace NugetForUnity
                     // copy the .nupkg inside the Unity project
                     File.Copy(cachedPackagePath, Path.Combine(baseDirectory, package.PackageFileName), true);
 
-                    static void ExtractPackageEntry(ZipArchiveEntry entry, string baseDir)
+                    void ExtractPackageEntry(ZipArchiveEntry entry, string baseDir)
                     {
                         var filePath = Path.Combine(baseDir, entry.FullName);
                         var directory = Path.GetDirectoryName(filePath) ??

--- a/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
@@ -210,13 +210,21 @@ namespace NugetForUnity
                         }
 
                         // go through all lib zip entries and find the best target framework, then unpack it
-                        var bestFrameworkMatch = TargetFrameworkResolver.TryGetBestTargetFramework(libs.Keys, framework => framework);
-                        if (bestFrameworkMatch != null)
+                        var bestFrameworkMatch = TargetFrameworkResolver.TryGetBestTargetFramework(libs, framework => framework.Key);
+                        if (bestFrameworkMatch.Value != null)
                         {
-                            foreach (var entry in libs[bestFrameworkMatch])
+                            NugetLogger.LogVerbose(
+                                "Selecting target framework directory '{0}' as best match for the package {1}",
+                                bestFrameworkMatch.Key,
+                                package);
+                            foreach (var entry in bestFrameworkMatch.Value)
                             {
                                 PackageContentManager.ExtractPackageEntry(entry, baseDirectory);
                             }
+                        }
+                        else
+                        {
+                            Debug.LogWarningFormat("Couldn't find a library folder with a supported target-framework for the package {0}", package);
                         }
                     }
 

--- a/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -170,9 +171,36 @@ namespace NugetForUnity
                     // unzip the package
                     using (var zip = ZipFile.OpenRead(cachedPackagePath))
                     {
+                        var libs = new Dictionary<string, List<ZipArchiveEntry>>();
+
                         foreach (var entry in zip.Entries)
                         {
-                            var filePath = Path.Combine(baseDirectory, entry.FullName);
+                            var entryFullName = entry.FullName;
+                            var filePath = Path.Combine(baseDirectory, entryFullName);
+
+                            if (ShouldSkipUnpackingOnPath(entryFullName, package.Id))
+                            {
+                                continue;
+                            }
+
+                            // we don't want to unpack all lib folders and then delete all but one; rather we will decide the best
+                            // target framework before unpacking, but first we need to collect all lib entries from zip
+                            if (entryFullName.StartsWith("lib"))
+                            {
+                                const int frameworkStartIndex = 4; // length of "lib/"
+                                var secondSlashIndex = entryFullName.IndexOf("/", frameworkStartIndex, StringComparison.Ordinal);
+                                var framework = entryFullName.Substring(frameworkStartIndex, secondSlashIndex - frameworkStartIndex);
+                                if (libs.ContainsKey(framework))
+                                {
+                                    libs[framework].Add(entry);
+                                }
+                                else
+                                {
+                                    libs[framework] = new List<ZipArchiveEntry> { entry };
+                                }
+
+                                continue;
+                            }
 
                             var directory = Path.GetDirectoryName(filePath) ??
                                             throw new InvalidOperationException($"Failed to get directory name of '{filePath}'");
@@ -189,6 +217,33 @@ namespace NugetForUnity
                             {
                                 var extractedFile = new FileInfo(filePath);
                                 extractedFile.Attributes |= FileAttributes.ReadOnly;
+                            }
+                        }
+
+                        // go through all lib zip entries and find the best target framework, then unpack it
+                        var bestFramework = TargetFrameworkResolver.TryGetBestTargetFramework(libs.Keys, key => key);
+                        if (bestFramework != null)
+                        {
+                            foreach (var entry in libs[bestFramework])
+                            {
+                                var filePath = Path.Combine(baseDirectory, entry.FullName);
+
+                                var directory = Path.GetDirectoryName(filePath) ??
+                                    throw new InvalidOperationException($"Failed to get directory name of '{filePath}'");
+                                Directory.CreateDirectory(directory);
+                                if (Directory.Exists(filePath))
+                                {
+                                    Debug.LogWarning($"The path {filePath} refers to an existing directory. Overwriting it may lead to data loss.");
+                                    continue;
+                                }
+
+                                entry.ExtractToFile(filePath, true);
+
+                                if (ConfigurationManager.NugetConfigFile.ReadOnlyPackageFiles)
+                                {
+                                    var extractedFile = new FileInfo(filePath);
+                                    extractedFile.Attributes |= FileAttributes.ReadOnly;
+                                }
                             }
                         }
                     }
@@ -227,6 +282,65 @@ namespace NugetForUnity
                     EditorUtility.ClearProgressBar();
                 }
             }
+        }
+
+        private static bool ShouldSkipUnpackingOnPath(string path, string packageId)
+        {
+            // skip a remnant .meta file that may exist from packages created by Unity
+            if (path.EndsWith($"{packageId}.nuspec.meta", StringComparison.Ordinal)) return true;
+
+            // skip directories & files that NuGet normally deletes
+            if (path.StartsWith("_rels", StringComparison.Ordinal) || path.Contains("/_rels/")) return true;
+            if (path.StartsWith("package", StringComparison.Ordinal) || path.Contains("/package/")) return true;
+            if (path.EndsWith($"{packageId}.nuspec", StringComparison.Ordinal)) return true;
+            if (path.EndsWith("[Content_Types].xml", StringComparison.Ordinal)) return true;
+
+            // Unity has no use for the build directory
+            if (path.StartsWith("build", StringComparison.Ordinal) || path.Contains("/build/")) return true;
+
+            // For now, skip src. We may use it later...
+            if (path.StartsWith("src", StringComparison.Ordinal) || path.Contains("/src/")) return true;
+
+            // Since we don't automatically fix up the runtime dll platforms, skip them until we improve support
+            // for this newer feature of nuget packages.
+            if (path.StartsWith("runtimes", StringComparison.Ordinal) || path.Contains("/runtimes/")) return true;
+
+            // Skip documentation folders since they sometimes have HTML docs with JavaScript, which Unity tried to parse as "UnityScript"
+            if (path.StartsWith("docs", StringComparison.Ordinal) || path.Contains("/docs/")) return true;
+
+            // Skip ref folder, as it is just used for compile-time reference and does not contain implementations.
+            // Leaving it results in "assembly loading" and "multiple pre-compiled assemblies with same name" errors
+            if (path.StartsWith("ref", StringComparison.Ordinal) || path.Contains("/ref/")) return true;
+
+            // Skip all PDB files since Unity uses Mono and requires MDB files, which causes it to output "missing MDB" errors
+            if (path.EndsWith(".pdb", StringComparison.Ordinal)) return true;
+
+            // Skip all folders that contain localization resource file
+            // Format of these entries is lib/<framework>/<language-code>/...
+            if (path.StartsWith("lib", StringComparison.Ordinal) || path.Contains("/lib/"))
+            {
+                var libSlashIndex = path.IndexOf("lib/", StringComparison.Ordinal) + 4;
+
+                var secondSlashIndex = path.IndexOf("/", libSlashIndex, StringComparison.Ordinal);
+                if (secondSlashIndex == -1)
+                {
+                    return false;
+                }
+
+                var thirdSlashIndex = path.IndexOf("/", secondSlashIndex + 1, StringComparison.Ordinal);
+                if (thirdSlashIndex == -1)
+                {
+                    return false;
+                }
+
+                var langLength = thirdSlashIndex - secondSlashIndex - 1;
+                if (langLength == 2 || langLength > 2 && path[secondSlashIndex + 3] == '-')
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/NuGetForUnity/Editor/PackageContentManager.cs
+++ b/src/NuGetForUnity/Editor/PackageContentManager.cs
@@ -204,6 +204,11 @@ namespace NugetForUnity
             return false;
         }
 
+        /// <summary>
+        ///     Extracts a file from a .nupkg <see cref="ZipArchive" /> into the <paramref name="baseDir" />.
+        /// </summary>
+        /// <param name="entry">The file entry from the .nupkg zip file.</param>
+        /// <param name="baseDir">The path of the directory where the package output should be placed.</param>
         internal static void ExtractPackageEntry(ZipArchiveEntry entry, string baseDir)
         {
             var filePath = Path.Combine(baseDir, entry.FullName);

--- a/src/NuGetForUnity/Editor/PackageContentManager.cs
+++ b/src/NuGetForUnity/Editor/PackageContentManager.cs
@@ -99,6 +99,15 @@ namespace NugetForUnity
             }
         }
 
+        /// <summary>
+        ///     Specifies if a file should be extracted from a .nupkg, because NuGetForUnity needs it.
+        /// </summary>
+        /// <param name="path">
+        ///     The path of the file inside the .nupkg it is relative starting from the package route. It always uses '/' as a slash on all
+        ///     platforms.
+        /// </param>
+        /// <param name="packageId">The id of the package that is extracted.</param>
+        /// <returns>True if the file can be skipped, is not needed.</returns>
         internal static bool ShouldSkipUnpackingOnPath(string path, string packageId)
         {
             // skip a remnant .meta file that may exist from packages created by Unity

--- a/src/NuGetForUnity/Editor/PackageContentManager.cs
+++ b/src/NuGetForUnity/Editor/PackageContentManager.cs
@@ -102,33 +102,69 @@ namespace NugetForUnity
         internal static bool ShouldSkipUnpackingOnPath(string path, string packageId)
         {
             // skip a remnant .meta file that may exist from packages created by Unity
-            if (path.EndsWith($"{packageId}.nuspec.meta", StringComparison.Ordinal)) return true;
+            if (path.EndsWith($"{packageId}.nuspec.meta", StringComparison.Ordinal))
+            {
+                return true;
+            }
 
             // skip directories & files that NuGet normally deletes
-            if (path.StartsWith("_rels/", StringComparison.Ordinal) || path.Contains("/_rels/")) return true;
-            if (path.StartsWith("package/", StringComparison.Ordinal) || path.Contains("/package/")) return true;
-            if (path.EndsWith($"{packageId}.nuspec", StringComparison.Ordinal)) return true;
-            if (path.EndsWith("[Content_Types].xml", StringComparison.Ordinal)) return true;
+            if (path.StartsWith("_rels/", StringComparison.Ordinal) || path.Contains("/_rels/"))
+            {
+                return true;
+            }
+
+            if (path.StartsWith("package/", StringComparison.Ordinal) || path.Contains("/package/"))
+            {
+                return true;
+            }
+
+            if (path.EndsWith($"{packageId}.nuspec", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (path.EndsWith("[Content_Types].xml", StringComparison.Ordinal))
+            {
+                return true;
+            }
 
             // Unity has no use for the build directory
-            if (path.StartsWith("build/", StringComparison.Ordinal) || path.Contains("/build/")) return true;
+            if (path.StartsWith("build/", StringComparison.Ordinal) || path.Contains("/build/"))
+            {
+                return true;
+            }
 
             // For now, skip src. We may use it later...
-            if (path.StartsWith("src/", StringComparison.Ordinal) || path.Contains("/src/")) return true;
+            if (path.StartsWith("src/", StringComparison.Ordinal) || path.Contains("/src/"))
+            {
+                return true;
+            }
 
             // Since we don't automatically fix up the runtime dll platforms, skip them until we improve support
             // for this newer feature of nuget packages.
-            if (path.StartsWith("runtimes/", StringComparison.Ordinal) || path.Contains("/runtimes/")) return true;
+            if (path.StartsWith("runtimes/", StringComparison.Ordinal) || path.Contains("/runtimes/"))
+            {
+                return true;
+            }
 
             // Skip documentation folders since they sometimes have HTML docs with JavaScript, which Unity tried to parse as "UnityScript"
-            if (path.StartsWith("docs/", StringComparison.Ordinal) || path.Contains("/docs/")) return true;
+            if (path.StartsWith("docs/", StringComparison.Ordinal) || path.Contains("/docs/"))
+            {
+                return true;
+            }
 
             // Skip ref folder, as it is just used for compile-time reference and does not contain implementations.
             // Leaving it results in "assembly loading" and "multiple pre-compiled assemblies with same name" errors
-            if (path.StartsWith("ref/", StringComparison.Ordinal) || path.Contains("/ref/")) return true;
+            if (path.StartsWith("ref/", StringComparison.Ordinal) || path.Contains("/ref/"))
+            {
+                return true;
+            }
 
             // Skip all PDB files since Unity uses Mono and requires MDB files, which causes it to output "missing MDB" errors
-            if (path.EndsWith(".pdb", StringComparison.Ordinal)) return true;
+            if (path.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
 
             // Skip all folders that contain localization resource file
             // Format of these entries is lib/<framework>/<language-code>/...
@@ -137,20 +173,20 @@ namespace NugetForUnity
             {
                 var libSlashIndex = path.IndexOf(libDirectoryName, StringComparison.Ordinal) + libDirectoryName.Length;
 
-                var secondSlashIndex = path.IndexOf("/", libSlashIndex, StringComparison.Ordinal);
+                var secondSlashIndex = path.IndexOf('/', libSlashIndex);
                 if (secondSlashIndex == -1)
                 {
                     return false;
                 }
 
-                var thirdSlashIndex = path.IndexOf("/", secondSlashIndex + 1, StringComparison.Ordinal);
+                var thirdSlashIndex = path.IndexOf('/', secondSlashIndex + 1);
                 if (thirdSlashIndex == -1)
                 {
                     return false;
                 }
 
                 var langLength = thirdSlashIndex - secondSlashIndex - 1;
-                if (langLength == 2 || langLength > 2 && path[secondSlashIndex + 3] == '-')
+                if (langLength == 2 || (langLength > 2 && path[secondSlashIndex + 3] == '-'))
                 {
                     return true;
                 }

--- a/src/NuGetForUnity/Editor/PackageContentManager.cs
+++ b/src/NuGetForUnity/Editor/PackageContentManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.IO.Compression;
 using NugetForUnity.Configuration;
 using NugetForUnity.Helper;
 using NugetForUnity.Models;
@@ -104,36 +105,37 @@ namespace NugetForUnity
             if (path.EndsWith($"{packageId}.nuspec.meta", StringComparison.Ordinal)) return true;
 
             // skip directories & files that NuGet normally deletes
-            if (path.StartsWith("_rels", StringComparison.Ordinal) || path.Contains("/_rels/")) return true;
-            if (path.StartsWith("package", StringComparison.Ordinal) || path.Contains("/package/")) return true;
+            if (path.StartsWith("_rels/", StringComparison.Ordinal) || path.Contains("/_rels/")) return true;
+            if (path.StartsWith("package/", StringComparison.Ordinal) || path.Contains("/package/")) return true;
             if (path.EndsWith($"{packageId}.nuspec", StringComparison.Ordinal)) return true;
             if (path.EndsWith("[Content_Types].xml", StringComparison.Ordinal)) return true;
 
             // Unity has no use for the build directory
-            if (path.StartsWith("build", StringComparison.Ordinal) || path.Contains("/build/")) return true;
+            if (path.StartsWith("build/", StringComparison.Ordinal) || path.Contains("/build/")) return true;
 
             // For now, skip src. We may use it later...
-            if (path.StartsWith("src", StringComparison.Ordinal) || path.Contains("/src/")) return true;
+            if (path.StartsWith("src/", StringComparison.Ordinal) || path.Contains("/src/")) return true;
 
             // Since we don't automatically fix up the runtime dll platforms, skip them until we improve support
             // for this newer feature of nuget packages.
-            if (path.StartsWith("runtimes", StringComparison.Ordinal) || path.Contains("/runtimes/")) return true;
+            if (path.StartsWith("runtimes/", StringComparison.Ordinal) || path.Contains("/runtimes/")) return true;
 
             // Skip documentation folders since they sometimes have HTML docs with JavaScript, which Unity tried to parse as "UnityScript"
-            if (path.StartsWith("docs", StringComparison.Ordinal) || path.Contains("/docs/")) return true;
+            if (path.StartsWith("docs/", StringComparison.Ordinal) || path.Contains("/docs/")) return true;
 
             // Skip ref folder, as it is just used for compile-time reference and does not contain implementations.
             // Leaving it results in "assembly loading" and "multiple pre-compiled assemblies with same name" errors
-            if (path.StartsWith("ref", StringComparison.Ordinal) || path.Contains("/ref/")) return true;
+            if (path.StartsWith("ref/", StringComparison.Ordinal) || path.Contains("/ref/")) return true;
 
             // Skip all PDB files since Unity uses Mono and requires MDB files, which causes it to output "missing MDB" errors
             if (path.EndsWith(".pdb", StringComparison.Ordinal)) return true;
 
             // Skip all folders that contain localization resource file
             // Format of these entries is lib/<framework>/<language-code>/...
-            if (path.StartsWith("lib", StringComparison.Ordinal) || path.Contains("/lib/"))
+            const string libDirectoryName = "lib/";
+            if (path.StartsWith(libDirectoryName, StringComparison.Ordinal) || path.Contains("/lib/"))
             {
-                var libSlashIndex = path.IndexOf("lib/", StringComparison.Ordinal) + 4;
+                var libSlashIndex = path.IndexOf(libDirectoryName, StringComparison.Ordinal) + libDirectoryName.Length;
 
                 var secondSlashIndex = path.IndexOf("/", libSlashIndex, StringComparison.Ordinal);
                 if (secondSlashIndex == -1)
@@ -155,6 +157,26 @@ namespace NugetForUnity
             }
 
             return false;
+        }
+
+        internal static void ExtractPackageEntry(ZipArchiveEntry entry, string baseDir)
+        {
+            var filePath = Path.Combine(baseDir, entry.FullName);
+            var directory = Path.GetDirectoryName(filePath) ?? throw new InvalidOperationException($"Failed to get directory name of '{filePath}'");
+            Directory.CreateDirectory(directory);
+            if (Directory.Exists(filePath))
+            {
+                Debug.LogWarning($"The path {filePath} refers to an existing directory. Overwriting it may lead to data loss.");
+                return;
+            }
+
+            entry.ExtractToFile(filePath, true);
+
+            if (ConfigurationManager.NugetConfigFile.ReadOnlyPackageFiles)
+            {
+                var extractedFile = new FileInfo(filePath);
+                extractedFile.Attributes |= FileAttributes.ReadOnly;
+            }
         }
 
         private static string GetPackageInstallDirectory(INugetPackageIdentifier package)

--- a/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
+++ b/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
@@ -125,7 +125,7 @@ namespace NugetForUnity
         /// <param name="availableTargetFrameworks">The list of available target-frameworks.</param>
         /// <param name="getTargetFrameworkString">A function to get the target-framework string.</param>
         /// <returns>The best matching target-framework.</returns>
-        public static T TryGetBestTargetFramework<T>(IReadOnlyCollection<T> availableTargetFrameworks, Func<T, string> getTargetFrameworkString)
+        public static T TryGetBestTargetFramework<T>(IReadOnlyCollection<T> availableTargetFrameworks, Func<T, string> getTargetFrameworkString) where T : class
         {
             var currentDotnetVersion = CurrentBuildTargetDotnetVersionCompatibilityLevel;
             var currentUnityVersion = UnityVersion.Current;
@@ -148,6 +148,7 @@ namespace NugetForUnity
                         var availableString = getTargetFrameworkString(availableTargetFramework).Replace(".", string.Empty);
                         return availableString.Equals(targetFrameworkSupport.Name, StringComparison.OrdinalIgnoreCase);
                     });
+
 
                 if (bestMatch != null)
                 {

--- a/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
+++ b/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
@@ -125,7 +125,7 @@ namespace NugetForUnity
         /// <param name="availableTargetFrameworks">The list of available target-frameworks.</param>
         /// <param name="getTargetFrameworkString">A function to get the target-framework string.</param>
         /// <returns>The best matching target-framework.</returns>
-        public static T TryGetBestTargetFramework<T>(IReadOnlyCollection<T> availableTargetFrameworks, Func<T, string> getTargetFrameworkString) where T : class
+        public static T TryGetBestTargetFramework<T>(IReadOnlyCollection<T> availableTargetFrameworks, Func<T, string> getTargetFrameworkString)
         {
             var currentDotnetVersion = CurrentBuildTargetDotnetVersionCompatibilityLevel;
             var currentUnityVersion = UnityVersion.Current;
@@ -148,7 +148,6 @@ namespace NugetForUnity
                         var availableString = getTargetFrameworkString(availableTargetFramework).Replace(".", string.Empty);
                         return availableString.Equals(targetFrameworkSupport.Name, StringComparison.OrdinalIgnoreCase);
                     });
-
 
                 if (bestMatch != null)
                 {

--- a/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
+++ b/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
@@ -149,7 +149,7 @@ namespace NugetForUnity
                         return availableString.Equals(targetFrameworkSupport.Name, StringComparison.OrdinalIgnoreCase);
                     });
 
-                if (bestMatch != null)
+                if (!Equals(bestMatch, default(T)))
                 {
                     return bestMatch;
                 }


### PR DESCRIPTION
Avoid deleting folders during clean after install by skipping the extraction of unneeded folders and files. [#557 ](https://github.com/GlitchEnzo/NuGetForUnity/issues/557)