### PR TITLE
Fix console output encoding + Fix command execution on Linux / MacOS

### DIFF
--- a/src/NuGetForUnity/Editor/Helper/NugetCliHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/NugetCliHelper.cs
@@ -5,6 +5,7 @@ using System.Text;
 using JetBrains.Annotations;
 using NugetForUnity.Configuration;
 using NugetForUnity.Models;
+using UnityEngine;
 using Debug = UnityEngine.Debug;
 
 namespace NugetForUnity.Helper
@@ -18,6 +19,8 @@ namespace NugetForUnity.Helper
         ///     The amount of time, in milliseconds, before the nuget.exe process times out and is killed.
         /// </summary>
         private const int TimeOut = 60000;
+
+        private static string dotNetExecutablePath;
 
         /// <summary>
         ///     Calls "nuget.exe pack" to create a .nupkg file based on the given .nuspec file.
@@ -36,7 +39,7 @@ namespace NugetForUnity.Helper
         }
 
         /// <summary>
-        ///     Calls "nuget.exe push" to push a .nupkf file to the server location defined in the NuGet.config file.
+        ///     Calls "nuget.exe push" to push a .nupkg file to the server location defined in the NuGet.config file.
         ///     Note: This differs slightly from NuGet's Push command by automatically calling Pack if the .nupkg doesn't already exist.
         /// </summary>
         /// <param name="nuspec">The NuspecFile which defines the package to push.  Only the ID and Version are used.</param>
@@ -64,6 +67,55 @@ namespace NugetForUnity.Helper
         }
 
         /// <summary>
+        ///     Creates a <see cref="ProcessStartInfo" /> configured to call a .Net '.exe' on the current operating system. This function ensures the correct
+        ///     output encoding is used. On Unix systems (Linux / MacOS) it also uses the 'dotnet' / 'mono' executable to start the
+        ///     <paramref name="executableFilePath" />.
+        /// </summary>
+        /// <param name="executableFilePath">The absolute file path to the .Net '.exe' file that should be started.</param>
+        /// <param name="arguments">The arguments that should be passed to the executable <paramref name="executableFilePath" />.</param>
+        /// <returns>The start info with the configuration.</returns>
+        internal static ProcessStartInfo CreateStartInfoForDotNetExecutable(string executableFilePath, string arguments)
+        {
+            var outputEncoding = Encoding.UTF8;
+            string executableToStart;
+            string executableArguments;
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                // Windows -> just call the .exe but use a special encoding
+                try
+                {
+                    // http://stackoverflow.com/questions/16803748/how-to-decode-cmd-output-correctly
+                    // Default = 65533, ASCII = ?, Unicode = nothing works at all, UTF-8 = 65533, UTF-7 = 242 = WORKS!, UTF-32 = nothing works at all
+                    outputEncoding = Encoding.GetEncoding(850);
+                }
+                catch (Exception e) when (e is ArgumentException || e is NotSupportedException)
+                {
+                    Debug.LogWarningFormat("Failed to get console output encoding 850 -> using UTF8 instead. Error: {0}", e);
+                }
+
+                executableToStart = executableFilePath;
+                executableArguments = arguments;
+            }
+            else
+            {
+                // Linux or MacOS -> we need 'mono' / 'dotnet' to run the executable
+                if (dotNetExecutablePath == null)
+                {
+                    dotNetExecutablePath = GetDotnetExecutablePath(outputEncoding);
+                }
+
+                executableToStart = dotNetExecutablePath;
+                executableArguments = $" {executableFilePath} {arguments}";
+                NugetLogger.LogVerbose("Changed command to call executable '{0}' with arguments '{1}'.", executableToStart, executableArguments);
+            }
+
+            return new ProcessStartInfo(executableToStart, executableArguments)
+            {
+                StandardOutputEncoding = outputEncoding, StandardErrorEncoding = outputEncoding,
+            };
+        }
+
+        /// <summary>
         ///     Runs nuget.exe using the given arguments.
         /// </summary>
         /// <param name="arguments">The arguments to run nuget.exe with.</param>
@@ -83,7 +135,7 @@ namespace NugetForUnity.Helper
             }
             else if (files.Length < 1)
             {
-                Debug.LogWarningFormat("No nuget.exe found! Attempting to install the NuGet.CommandLine package.");
+                Debug.LogWarningFormat("No nuget.exe found! Attempting to install the latest version of the NuGet.CommandLine package.");
                 NugetPackageInstaller.InstallIdentifier(new NugetPackageIdentifier("NuGet.CommandLine", null));
                 files = Directory.GetFiles(toolsPackagesFolder, "nuget.exe", SearchOption.AllDirectories);
                 if (files.Length < 1)
@@ -95,54 +147,70 @@ namespace NugetForUnity.Helper
 
             NugetLogger.LogVerbose("Running: {0} \nArgs: {1}", files[0], arguments);
 
-            string fileName;
-            string commandLine;
-            if (Environment.OSVersion.Platform == PlatformID.MacOSX)
+            var startInfo = CreateStartInfoForDotNetExecutable(files[0], arguments);
+            startInfo.RedirectStandardError = true;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
+            using (var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start process."))
             {
-                // ATTENTION: you must install mono running on your mac, we use this mono to run `nuget.exe`
-                fileName = "/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono";
-                commandLine = " " + files[0] + " " + arguments;
-                NugetLogger.LogVerbose("command: " + commandLine);
+                if (!process.WaitForExit(TimeOut))
+                {
+                    Debug.LogWarning("NuGet took too long to finish.  Killing operation.");
+                    process.Kill();
+                }
+
+                var error = process.StandardError.ReadToEnd();
+                if (!string.IsNullOrEmpty(error))
+                {
+                    Debug.LogError(error);
+                }
+
+                var output = process.StandardOutput.ReadToEnd();
+                if (logOutput && !string.IsNullOrEmpty(output))
+                {
+                    Debug.Log(output);
+                }
             }
-            else
+        }
+
+        private static string GetDotnetExecutablePath(Encoding outputEncoding)
+        {
+            // search for full path to 'dotnet' or 'mono' executable
+            foreach (var commandLineToolName in new[] { "dotnet", "mono" })
             {
-                fileName = files[0];
-                commandLine = arguments;
+                try
+                {
+                    using (var process = Process.Start(
+                                             new ProcessStartInfo("which", commandLineToolName)
+                                             {
+                                                 RedirectStandardOutput = true, StandardOutputEncoding = outputEncoding,
+                                             }) ??
+                                         throw new InvalidOperationException("Failed to start process."))
+                    {
+                        process.WaitForExit();
+
+                        // which either returns nothing (not found) or the full path to the executable.
+                        var commandPath = process.StandardOutput.ReadLine();
+                        if (!string.IsNullOrEmpty(commandPath))
+                        {
+                            return commandPath;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarningFormat(
+                        "Failed to get path of command {0} using 'which' command -> using '{0}' as a command path instead. Error: {1}",
+                        commandLineToolName,
+                        e);
+                    return commandLineToolName;
+                }
             }
 
-            var process = Process.Start(
-                              new ProcessStartInfo(fileName, commandLine)
-                              {
-                                  RedirectStandardError = true,
-                                  RedirectStandardOutput = true,
-                                  UseShellExecute = false,
-                                  CreateNoWindow = true,
-
-                                  // WorkingDirectory = Path.GettargetFramework(files[0]),
-
-                                  // http://stackoverflow.com/questions/16803748/how-to-decode-cmd-output-correctly
-                                  // Default = 65533, ASCII = ?, Unicode = nothing works at all, UTF-8 = 65533, UTF-7 = 242 = WORKS!, UTF-32 = nothing works at all
-                                  StandardOutputEncoding = Encoding.GetEncoding(850),
-                              }) ??
-                          throw new InvalidOperationException("Failed to start process.");
-
-            if (!process.WaitForExit(TimeOut))
-            {
-                Debug.LogWarning("NuGet took too long to finish.  Killing operation.");
-                process.Kill();
-            }
-
-            var error = process.StandardError.ReadToEnd();
-            if (!string.IsNullOrEmpty(error))
-            {
-                Debug.LogError(error);
-            }
-
-            var output = process.StandardOutput.ReadToEnd();
-            if (logOutput && !string.IsNullOrEmpty(output))
-            {
-                Debug.Log(output);
-            }
+            Debug.LogWarning(
+                "Can't find 'dotnet' or 'mono' executable. Is it installed on your system? It is needed to run dotnet .exe files. Try to use 'dotnet' as a command even if 'which dotnet' didn't find it.");
+            return "dotnet";
         }
     }
 }


### PR DESCRIPTION
fixes #574 

- Fix output encoding for non windows platforms
- use mono / dotnet to run .exe on Linux / MacOS
- remove duplicate code from NugetCliHelper / CredentialProviderHelper
