### PR TITLE
allow packages without sub-directories inside the lib folder

### DIFF
--- a/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
@@ -193,7 +193,8 @@ namespace NugetForUnity
                                 var secondSlashIndex = entryFullName.IndexOf('/', frameworkStartIndex);
                                 if (secondSlashIndex == -1)
                                 {
-                                    // a file inside lib folder -> we skip it
+                                    // a file inside lib folder -> we keep it. This is to support packages that have no framework dependent sub directories.
+                                    PackageContentManager.ExtractPackageEntry(entry, baseDirectory);
                                     continue;
                                 }
 
@@ -333,7 +334,10 @@ namespace NugetForUnity
             }
         }
 
-        private static void FillFrameworkZipEntries(IDictionary<string, List<ZipArchiveEntry>> frameworkZipEntries, string framework, ZipArchiveEntry entry)
+        private static void FillFrameworkZipEntries(
+            IDictionary<string, List<ZipArchiveEntry>> frameworkZipEntries,
+            string framework,
+            ZipArchiveEntry entry)
         {
             if (!frameworkZipEntries.TryGetValue(framework, out var entryList))
             {

--- a/src/NuGetForUnity/Editor/PackageContentManager.cs
+++ b/src/NuGetForUnity/Editor/PackageContentManager.cs
@@ -108,7 +108,6 @@ namespace NugetForUnity
         ///     The path of the file inside the .nupkg it is relative starting from the package route. It always uses '/' as a slash on all
         ///     platforms.
         /// </param>
-        /// <param name="packageId">The id of the package that is extracted.</param>
         /// <returns>True if the file can be skipped, is not needed.</returns>
         internal static bool ShouldSkipUnpackingOnPath([NotNull] string path)
         {
@@ -207,7 +206,7 @@ namespace NugetForUnity
         ///     Extracts source files from a source code .nupkg <see cref="ZipArchive" /> into the <paramref name="baseDir" />/Sources.
         /// </summary>
         /// <param name="entries">The source file entries from the .nupkg zip file.</param>
-        /// <param name="baseDir">The path of the directory under which the 'Sources' subdirectory should be placed.</param>
+        /// <param name="baseDir">The path of the directory under which the 'Sources' sub-directory should be placed.</param>
         internal static void ExtractPackageSources([NotNull] List<ZipArchiveEntry> entries, [NotNull] string baseDir)
         {
             if (entries.Count == 0)


### PR DESCRIPTION
fixes #583
We now extract files that are in the root `/lib` folder and not inside a framework depended sub folder.
![image](https://github.com/GlitchEnzo/NuGetForUnity/assets/53140583/16c65d77-c36f-46c9-bb25-a92a5b7969f1)