### PR TITLE
Correctly order pre-release versions

### DIFF
--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -495,6 +495,7 @@ public class NuGetTests
     [TestCase("1.2.3-rc1+1234", "1.2.3-rc2")]
     [TestCase("1.2.3-rc1+1234", "1.2.3-rc2+1234")]
     [TestCase("1.0.0", "1.0.0.10")]
+    [TestCase("1.0.0-beta.9", "1.0.0-beta.10")]
     public void VersionComparison(string smallerVersion, string greaterVersion)
     {
         var localNugetPackageSource = new NugetPackageSourceLocal("test", "test");

--- a/src/NuGetForUnity/Editor/Models/NugetPackageIdentifier.cs
+++ b/src/NuGetForUnity/Editor/Models/NugetPackageIdentifier.cs
@@ -269,7 +269,7 @@ namespace NugetForUnity.Models
             Justification = "We only edit the version / id before we use the hash (stroe it in a dictionary).")]
         public override int GetHashCode()
         {
-            return Id.GetHashCode() ^ PackageVersion.GetHashCode();
+            return GetHashCodeOfId() ^ PackageVersion.GetHashCode();
         }
 
         /// <summary>
@@ -279,6 +279,15 @@ namespace NugetForUnity.Models
         public override string ToString()
         {
             return $"{Id}.{Version}";
+        }
+
+        private int GetHashCodeOfId()
+        {
+#if UNITY_2021_2_OR_NEWER
+            return Id.GetHashCode(StringComparison.OrdinalIgnoreCase);
+#else
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(Id);
+#endif
         }
     }
 }

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceLocal.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceLocal.cs
@@ -302,24 +302,26 @@ namespace NugetForUnity.PackageSource
         }
 
         /// <summary>
-        ///     Gets a list of available packages from a local source (not a web server) that are upgrades for the given list of installed packages.
+        ///     Gets a list of available packages from a local source (not a web server) that are versions / upgrade or downgrade of the given list of installed
+        ///     packages.
         /// </summary>
         /// <param name="packages">The list of packages to use to find updates.</param>
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
-        /// <returns>A list of all updates available.</returns>
+        /// <returns>A list of all updates / downgrades available.</returns>
         [NotNull]
         [ItemNotNull]
         private List<INugetPackage> GetLocalUpdates([NotNull] [ItemNotNull] IEnumerable<INugetPackage> packages, bool includePrerelease = false)
         {
             var updates = new List<INugetPackage>();
-            foreach (var installedPackage in packages)
+            foreach (var packageToSearch in packages)
             {
-                var availablePackages = GetLocalPackages($"{installedPackage.Id}*", false, includePrerelease);
+                var availablePackages = GetLocalPackages($"{packageToSearch.Id}*", false, includePrerelease);
                 foreach (var availablePackage in availablePackages)
                 {
-                    if (installedPackage.Id.Equals(availablePackage.Id, StringComparison.OrdinalIgnoreCase) &&
-                        installedPackage.CompareTo(availablePackage) < 0)
+                    if (packageToSearch.Id.Equals(availablePackage.Id, StringComparison.OrdinalIgnoreCase))
                     {
+                        // keep the manually installed state
+                        availablePackage.IsManuallyInstalled = packageToSearch.IsManuallyInstalled;
                         updates.Add(availablePackage);
                     }
                 }

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV2.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV2.cs
@@ -294,6 +294,7 @@ namespace NugetForUnity.PackageSource
                 try
                 {
                     var newPackages = GetPackagesFromUrl(url);
+                    CopyIsManuallyInstalled(newPackages, packagesCollection);
                     updates.AddRange(newPackages);
                 }
                 catch (Exception e)
@@ -521,6 +522,17 @@ namespace NugetForUnity.PackageSource
 
             NugetLogger.LogVerbose("NugetPackageSource.GetUpdatesFallback took {0} ms", stopwatch.ElapsedMilliseconds);
             return updates;
+        }
+
+        private void CopyIsManuallyInstalled(List<INugetPackage> newPackages, ICollection<INugetPackage> packagesToUpdate)
+        {
+            foreach (var newPackage in newPackages)
+            {
+                newPackage.IsManuallyInstalled =
+                    packagesToUpdate.FirstOrDefault(packageToUpdate => packageToUpdate.Id.Equals(newPackage.Id, StringComparison.OrdinalIgnoreCase))
+                        ?.IsManuallyInstalled ??
+                    false;
+            }
         }
     }
 }

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
@@ -247,6 +247,7 @@ namespace NugetForUnity.PackageSource
                 .GetAwaiter()
                 .GetResult();
 
+            CopyIsManuallyInstalled(packagesFromServer, packagesToFetch);
             packagesFromServer.Sort();
             return packagesFromServer;
         }
@@ -312,6 +313,17 @@ namespace NugetForUnity.PackageSource
             apiClient = new NugetApiClientV3(SavedPath);
             ApiClientCache.Add(SavedPath, apiClient);
             return apiClient;
+        }
+
+        private void CopyIsManuallyInstalled(List<INugetPackage> newPackages, ICollection<INugetPackage> packagesToUpdate)
+        {
+            foreach (var newPackage in newPackages)
+            {
+                newPackage.IsManuallyInstalled =
+                    packagesToUpdate.FirstOrDefault(packageToUpdate => packageToUpdate.Id.Equals(newPackage.Id, StringComparison.OrdinalIgnoreCase))
+                        ?.IsManuallyInstalled ??
+                    false;
+            }
         }
     }
 }

--- a/src/NuGetForUnity/Editor/Ui/NugetWindow.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetWindow.cs
@@ -645,7 +645,7 @@ namespace NugetForUnity.Ui
             EditorGUI.LabelField(rectangle, " Installed packages", headerStyle);
             if (packages.Exists(package => package.IsManuallyInstalled))
             {
-                DrawPackages(packages.TakeWhile(package => package.IsManuallyInstalled), true);
+                DrawPackages(packages.Where(package => package.IsManuallyInstalled), true);
             }
             else
             {
@@ -658,7 +658,7 @@ namespace NugetForUnity.Ui
             showImplicitlyInstalled = EditorGUI.Foldout(rectangle, showImplicitlyInstalled, "Implicitly installed packages", true, GetFoldoutStyle());
             if (showImplicitlyInstalled)
             {
-                DrawPackages(packages.SkipWhile(package => package.IsManuallyInstalled), true);
+                DrawPackages(packages.Where(package => !package.IsManuallyInstalled), true);
             }
         }
 

--- a/src/NuGetForUnity/Editor/Ui/NugetWindow.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetWindow.cs
@@ -163,14 +163,37 @@ namespace NugetForUnity.Ui
         {
             get
             {
+                IEnumerable<INugetPackage> result;
                 if (string.IsNullOrWhiteSpace(updatesSearchTerm) || updatesSearchTerm == "Search")
                 {
-                    return updatePackages;
+                    result = updatePackages;
+                }
+                else
+                {
+                    result = updatePackages.Where(
+                        package => package.Id.IndexOf(updatesSearchTerm, StringComparison.InvariantCultureIgnoreCase) >= 0 ||
+                                   package.Title?.IndexOf(updatesSearchTerm, StringComparison.InvariantCultureIgnoreCase) >= 0);
                 }
 
-                return updatePackages.Where(
-                        package => package.Id.IndexOf(updatesSearchTerm, StringComparison.InvariantCultureIgnoreCase) >= 0 ||
-                                   package.Title?.IndexOf(updatesSearchTerm, StringComparison.InvariantCultureIgnoreCase) >= 0)
+                var installedPackages = InstalledPackagesManager.InstalledPackages;
+
+                // filter not updatable / not downgradable packages
+                return result.Where(
+                        package =>
+                        {
+                            var installed = installedPackages.FirstOrDefault(p => p.Id.Equals(package.Id, StringComparison.OrdinalIgnoreCase));
+
+                            if (installed == null || package.Versions.Count == 0)
+                            {
+                                // normally shouldn't happen but for now include it in the result
+                                return true;
+                            }
+
+                            // we do not want to show packages that have no updates if we're showing updates
+                            // similarly, we do not show packages that are on the lowest possible version if we're showing downgrades
+                            return (showDowngrades && installed.PackageVersion > package.Versions[package.Versions.Count - 1]) ||
+                                   (!showDowngrades && installed.PackageVersion < package.Versions[0]);
+                        })
                     .ToList();
             }
         }
@@ -429,6 +452,15 @@ namespace NugetForUnity.Ui
             return cachedFoldoutStyle;
         }
 
+        private static void DrawNoDataAvailableInfo(string message)
+        {
+            EditorStyles.label.fontStyle = FontStyle.Bold;
+            EditorStyles.label.fontSize = 14;
+            EditorGUILayout.LabelField(message, GUILayout.Height(20));
+            EditorStyles.label.fontSize = 10;
+            EditorStyles.label.fontStyle = FontStyle.Normal;
+        }
+
         /// <summary>
         ///     Called when enabling the window.
         /// </summary>
@@ -569,15 +601,11 @@ namespace NugetForUnity.Ui
             var filteredUpdatePackages = FilteredUpdatePackages;
             if (filteredUpdatePackages.Count > 0)
             {
-                DrawPackages(filteredUpdatePackages, true);
+                DrawPackagesSplittedByManuallyInstalled(filteredUpdatePackages);
             }
             else
             {
-                EditorStyles.label.fontStyle = FontStyle.Bold;
-                EditorStyles.label.fontSize = 14;
-                EditorGUILayout.LabelField("There are no updates available!", GUILayout.Height(20));
-                EditorStyles.label.fontSize = 10;
-                EditorStyles.label.fontStyle = FontStyle.Normal;
+                DrawNoDataAvailableInfo("There are no updates available!");
             }
 
             EditorGUILayout.EndVertical();
@@ -598,36 +626,40 @@ namespace NugetForUnity.Ui
             var installedPackages = FilteredInstalledPackages;
             if (installedPackages.Count > 0)
             {
-                var headerStyle = GetHeaderStyle();
-
-                EditorGUILayout.LabelField("Installed packages", headerStyle, GUILayout.Height(20));
-                DrawPackages(installedPackages.TakeWhile(package => package.IsManuallyInstalled), true);
-
-                var rectangle = EditorGUILayout.GetControlRect(true, 20f, headerStyle);
-                EditorGUI.LabelField(rectangle, string.Empty, headerStyle);
-
-                showImplicitlyInstalled = EditorGUI.Foldout(
-                    rectangle,
-                    showImplicitlyInstalled,
-                    "Implicitly installed packages",
-                    true,
-                    GetFoldoutStyle());
-                if (showImplicitlyInstalled)
-                {
-                    DrawPackages(installedPackages.SkipWhile(package => package.IsManuallyInstalled), true);
-                }
+                DrawPackagesSplittedByManuallyInstalled(installedPackages);
             }
             else
             {
-                EditorStyles.label.fontStyle = FontStyle.Bold;
-                EditorStyles.label.fontSize = 14;
-                EditorGUILayout.LabelField("There are no packages installed!", GUILayout.Height(20));
-                EditorStyles.label.fontSize = 10;
-                EditorStyles.label.fontStyle = FontStyle.Normal;
+                DrawNoDataAvailableInfo("There are no packages installed!");
             }
 
             EditorGUILayout.EndVertical();
             EditorGUILayout.EndScrollView();
+        }
+
+        private void DrawPackagesSplittedByManuallyInstalled(List<INugetPackage> packages)
+        {
+            var headerStyle = GetHeaderStyle();
+
+            var rectangle = EditorGUILayout.GetControlRect(true, 20f, headerStyle);
+            EditorGUI.LabelField(rectangle, " Installed packages", headerStyle);
+            if (packages.Exists(package => package.IsManuallyInstalled))
+            {
+                DrawPackages(packages.TakeWhile(package => package.IsManuallyInstalled), true);
+            }
+            else
+            {
+                DrawNoDataAvailableInfo("There are no explicitly installed packages.");
+            }
+
+            rectangle = EditorGUILayout.GetControlRect(true, 20f, headerStyle);
+            EditorGUI.LabelField(rectangle, string.Empty, headerStyle);
+
+            showImplicitlyInstalled = EditorGUI.Foldout(rectangle, showImplicitlyInstalled, "Implicitly installed packages", true, GetFoldoutStyle());
+            if (showImplicitlyInstalled)
+            {
+                DrawPackages(packages.SkipWhile(package => package.IsManuallyInstalled), true);
+            }
         }
 
         /// <summary>
@@ -890,17 +922,6 @@ namespace NugetForUnity.Ui
         {
             var installedPackages = InstalledPackagesManager.InstalledPackages;
             var installed = installedPackages.FirstOrDefault(p => p.Id.Equals(package.Id, StringComparison.OrdinalIgnoreCase));
-
-            // if we are on the update tab, we do not want to show packages that have no updates if we're showing updates; similarly, we do not
-            // show packages that are on the lowest possible version if we're showing downgrades
-            if (currentTab == NugetWindowTab.UpdatesTab &&
-                installed != null &&
-                package.Versions.Count >= 1 &&
-                ((showDowngrades && installed.PackageVersion <= package.Versions[package.Versions.Count - 1]) ||
-                 (!showDowngrades && installed.PackageVersion >= package.Versions[0])))
-            {
-                return;
-            }
 
             using (new EditorGUILayout.HorizontalScope())
             {


### PR DESCRIPTION
- fix pre-release version ordering when it contains numeric release-labels fixes #607
e.g. the version `1.0.0-beta.10` is now considered higher / newer that the version `1.0.0-beta.9`
- separate available updates / downgrades by manually installed
Use same 'Implicitly installed packages' section as on the 'Installed Tab'.