### PR TITLE
Option to install in /Packages/NuGetAssets

### DIFF
--- a/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
@@ -87,25 +87,24 @@ namespace NugetForUnity.Configuration
         ///     The underlying absolute path where packages are to be installed.
         /// </summary>
         [NotNull]
-        private string underlyingRepositoryPath= Path.GetFullPath(Path.Combine(Application.dataPath, "Packages"));
+        private string underlyingRepositoryPath { get; set; } = Path.GetFullPath(Path.Combine(Application.dataPath, "Packages"));
         
         /// <summary>
         ///     Gets the absolute path where packages are to be installed.
         /// </summary>
         [NotNull]
-        public string RepositoryPath { get=>underlyingRepositoryPath;
-             set => underlyingRepositoryPath = savedRepositoryPath = value;
+        public string RepositoryPath 
+        { 
+            get=>underlyingRepositoryPath;
+            set => underlyingRepositoryPath = savedRepositoryPath = value;
         }
 
         /// <summary>
         ///     Gets the relative path to directory where packages are to be installed. The path is relative to the folder containing the 'NuGet.config' file.
         /// </summary>
         [NotNull]
-        public string RelativeRepositoryPath
-        {
-            get => PathHelper.GetRelativePath(Application.dataPath, RepositoryPath);
-            private set => savedRepositoryPath=RepositoryPath = Path.GetFullPath(Path.Combine(Application.dataPath, value));
-        }
+        public string RelativeRepositoryPath => PathHelper.GetRelativePath(Application.dataPath, RepositoryPath);
+
         /// <summary>
         ///     Gets the default package source to push NuGet packages to.
         /// </summary>

--- a/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
@@ -84,11 +84,28 @@ namespace NugetForUnity.Configuration
         public INugetPackageSource ActivePackageSource { get; private set; }
 
         /// <summary>
+        ///     The underlying absolute path where packages are to be installed.
+        /// </summary>
+        [NotNull]
+        private string underlyingRepositoryPath= Path.GetFullPath(Path.Combine(Application.dataPath, "Packages"));
+        
+        /// <summary>
         ///     Gets the absolute path where packages are to be installed.
         /// </summary>
         [NotNull]
-        public string RepositoryPath { get; private set; } = Path.GetFullPath(Path.Combine(Application.dataPath, "Packages"));
+        public string RepositoryPath { get=>underlyingRepositoryPath;
+             set => underlyingRepositoryPath = savedRepositoryPath = value;
+        }
 
+        /// <summary>
+        ///     Gets the relative path to directory where packages are to be installed. The path is relative to the folder containing the 'NuGet.config' file.
+        /// </summary>
+        [NotNull]
+        public string RelativeRepositoryPath
+        {
+            get => PathHelper.GetRelativePath(Application.dataPath, RepositoryPath);
+            private set => savedRepositoryPath=RepositoryPath = Path.GetFullPath(Path.Combine(Application.dataPath, value));
+        }
         /// <summary>
         ///     Gets the default package source to push NuGet packages to.
         /// </summary>

--- a/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
@@ -172,14 +172,40 @@ namespace NugetForUnity.Ui
                     }
                 }
             }
-
+            
             if (shouldShowPackagesConfigPathWarning)
             {
                 EditorGUILayout.HelpBox(
                     "The packages.config is placed outside of Assets folder, this disables the functionality of automatically restoring packages if the file is changed on the disk.",
                     MessageType.Warning);
             }
+            
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                var repositoryPath = ConfigurationManager.NugetConfigFile.RepositoryPath;
 
+                GUILayout.Label(
+                    new GUIContent("Repository path:", $"Absolute path: {repositoryPath}"),
+                    GUILayout.Width(EditorGUIUtility.labelWidth));
+                GUILayout.Label(ConfigurationManager.NugetConfigFile.RelativeRepositoryPath);
+                if (GUILayout.Button("Create NuGetAssets Directory", GUILayout.Width(200)))
+                {
+                    InstalledPackagesManager.CreateNuGetAssetsDirectory();
+                }
+                if (GUILayout.Button("Browse", GUILayout.Width(100)))
+                {
+                    var newPath = EditorUtility.OpenFolderPanel("Select Folder", repositoryPath, string.Empty);
+
+                    if (!string.IsNullOrEmpty(newPath) && newPath != repositoryPath)
+                    {
+                        InstalledPackagesManager.Move(newPath);
+                        preferencesChangedThisFrame = true;
+                    }
+                }
+                
+                
+            }
+            
             var requestTimeout = EditorGUILayout.IntField(
                 new GUIContent(
                     "Request Timeout in seconds",


### PR DESCRIPTION
Add an option to install not to  Assets Folder but, Packages/NuGetAssets Folder 
![スクリーンショット 2024-01-21 175748](https://github.com/GlitchEnzo/NuGetForUnity/assets/90429982/59e2ee2a-0f39-4f9d-ac38-10fe12156a75)
