### PR TITLE
Add basic proxy support for NuGet API V3

### DIFF
--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -44,14 +44,7 @@ namespace NugetForUnity.PackageSource
 
         [NonSerialized]
         [NotNull]
-        private readonly HttpClient httpClient = new HttpClient(
-            new HttpClientHandler
-            {
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-#if UNITY_EDITOR_WIN
-                Proxy = WebRequest.GetSystemWebProxy(),
-#endif
-            });
+        private readonly HttpClient httpClient;
 
         [NonSerialized]
         [CanBeNull]
@@ -90,6 +83,23 @@ namespace NugetForUnity.PackageSource
             apiIndexJsonUrl = new Uri(url);
 
             InitializeFromSessionState();
+
+            // On Windows, Mono HttpClient does not automatically pick up proxy settings.
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                httpClient = new HttpClient(new HttpClientHandler
+                {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                    Proxy = WebRequest.GetSystemWebProxy()
+                });
+            }
+            else
+            {
+                httpClient = new HttpClient(new HttpClientHandler
+                {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                });
+            }
         }
 
         /// <summary>

--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -82,24 +82,16 @@ namespace NugetForUnity.PackageSource
 
             apiIndexJsonUrl = new Uri(url);
 
-            InitializeFromSessionState();
-
-            // On Windows, Mono HttpClient does not automatically pick up proxy settings.
+            var handler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
             if (Application.platform == RuntimePlatform.WindowsEditor)
             {
-                httpClient = new HttpClient(new HttpClientHandler
-                {
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                    Proxy = WebRequest.GetSystemWebProxy()
-                });
+                // On Windows, Mono HttpClient does not automatically pick up proxy settings.
+                handler.Proxy = WebRequest.GetSystemWebProxy();
             }
-            else
-            {
-                httpClient = new HttpClient(new HttpClientHandler
-                {
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-                });
-            }
+
+            httpClient = new HttpClient(handler);
+
+            InitializeFromSessionState();
         }
 
         /// <summary>

--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -45,7 +45,11 @@ namespace NugetForUnity.PackageSource
         [NonSerialized]
         [NotNull]
         private readonly HttpClient httpClient = new HttpClient(
-            new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate });
+            new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                Proxy = WebRequest.DefaultWebProxy
+            });
 
         [NonSerialized]
         [CanBeNull]

--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -48,7 +48,9 @@ namespace NugetForUnity.PackageSource
             new HttpClientHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                Proxy = WebRequest.DefaultWebProxy
+#if UNITY_EDITOR_WIN
+                Proxy = WebRequest.GetSystemWebProxy(),
+#endif
             });
 
         [NonSerialized]


### PR DESCRIPTION
* addresses proxy connection issue #495

The default proxy setup was missing in HttpClient/HttpClientHander initializaion.
By adding WebRequest.DefaultWebProxy client will look for HTTP_PROXY, NO_PROXY environment variables if it exists.

Tested on Unity 2018.3.0, 2022.3.18, and Squid 5.7.