### PR TITLE
update GitHub action to use newer versions

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Get changed files in the .github folder
       if: github.event_name == 'pull_request_target'
       id: changedWorkflowFiles
-      uses: tj-actions/changed-files@v35
+      uses: tj-actions/changed-files@v42
       with:
         files: |
           .github/**

--- a/.github/workflows/activation.yml
+++ b/.github/workflows/activation.yml
@@ -12,7 +12,7 @@ jobs:
         uses: game-ci/unity-request-activation-file@v2
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
       - name: Expose as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,10 @@ jobs:
 
     steps:
       - name: Checkout action file
-        uses: Bhacaz/checkout-files@v2
+        uses: actions/checkout@v4
         with:
-          files: .github/actions/checkout/action.yml
+          sparse-checkout: .github/actions/checkout/action.yml
+          sparse-checkout-cone-mode: false
 
       - name: Checkout
         uses: ./.github/actions/checkout
@@ -56,9 +57,10 @@ jobs:
 
     steps:
       - name: Checkout action file
-        uses: Bhacaz/checkout-files@v2
+        uses: actions/checkout@v4
         with:
-          files: .github/actions/checkout/action.yml
+          sparse-checkout: .github/actions/checkout/action.yml
+          sparse-checkout-cone-mode: false
 
       - name: Checkout
         uses: ./.github/actions/checkout
@@ -69,7 +71,7 @@ jobs:
           version: ${{ needs.determineVersionNumber.outputs.version }}
 
       - name: Upload NuGetForUnity dlls
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: NuGetForUnity-dlls
           path: |
@@ -81,7 +83,7 @@ jobs:
       - name: Check if files in NuGetForUnity.PluginAPI changed
         if: github.event_name == 'pull_request_target'
         id: changedPluginApiCode
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v42
         with:
           files: |
             src/NuGetForUnity.PluginAPI/**.cs
@@ -89,7 +91,7 @@ jobs:
       - name: Check if NuGetForUnity.PluginAPI.dll is updated
         if: github.event_name == 'pull_request_target'
         id: changedPluginApiDll
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v42
         with:
           files: |
             src/NuGetForUnity/Editor/PluginAPI/NuGetForUnity.PluginAPI.dll
@@ -112,15 +114,16 @@ jobs:
 
     steps:
       - name: Checkout action file
-        uses: Bhacaz/checkout-files@v2
+        uses: actions/checkout@v4
         with:
-          files: .github/actions/checkout/action.yml
+          sparse-checkout: .github/actions/checkout/action.yml
+          sparse-checkout-cone-mode: false
 
       - name: Checkout
         uses: ./.github/actions/checkout
 
       - name: Download NuGetForUnity dlls
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: NuGetForUnity-dlls
           path: ./src/NuGetForUnity.Packager/Assets/NuGet/Editor
@@ -145,7 +148,7 @@ jobs:
           version: ${{ needs.determineVersionNumber.outputs.version }}
 
       - name: Upload UnityPackage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: NuGetForUnity.${{ needs.determineVersionNumber.outputs.version }}.unitypackage
           path: ./src/NuGetForUnity.Packager/NugetForUnity.unitypackage
@@ -158,15 +161,16 @@ jobs:
 
     steps:
       - name: Checkout action file
-        uses: Bhacaz/checkout-files@v2
+        uses: actions/checkout@v4
         with:
-          files: .github/actions/checkout/action.yml
+          sparse-checkout: .github/actions/checkout/action.yml
+          sparse-checkout-cone-mode: false
 
       - name: Checkout
         uses: ./.github/actions/checkout
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "8.0.x"
 
@@ -195,7 +199,7 @@ jobs:
           --source https://api.nuget.org/v3/index.json
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: NuGetForUnity-NuGetPackages
           path: |
@@ -208,9 +212,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout action file
-        uses: Bhacaz/checkout-files@v2
+        uses: actions/checkout@v4
         with:
-          files: .github/actions/checkout/action.yml
+          sparse-checkout: .github/actions/checkout/action.yml
+          sparse-checkout-cone-mode: false
 
       - name: Checkout
         uses: ./.github/actions/checkout
@@ -239,15 +244,16 @@ jobs:
 
     steps:
       - name: Checkout action file
-        uses: Bhacaz/checkout-files@v2
+        uses: actions/checkout@v4
         with:
-          files: .github/actions/checkout/action.yml
+          sparse-checkout: .github/actions/checkout/action.yml
+          sparse-checkout-cone-mode: false
 
       - name: Checkout
         uses: ./.github/actions/checkout
 
       - name: Download NuGetForUnity.Cli NuGet package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: NuGetForUnity-NuGetPackages
           path: .

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -97,8 +97,9 @@ public class NuGetTests
             var meta = (PluginImporter)AssetImporter.GetAtPath(path);
 
 #if UNITY_2022_3_OR_NEWER
+
             // somehow unity doesn't import the .dll on newer unity version
-            var postprocessor = new NugetAssetPostprocessor() { assetPath = path };
+            var postprocessor = new NugetAssetPostprocessor { assetPath = path };
             postprocessor.GetType().GetMethod("OnPreprocessAsset", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(postprocessor, null);
 #endif
 
@@ -162,14 +163,16 @@ public class NuGetTests
 
             foreach (var roslynAnalyzerVersion in roslynAnalyzerVersions)
             {
-                var path = $"Assets/Packages/{jsonPackageId.Id}.{jsonPackageId.Version}/analyzers/dotnet/roslyn{roslynAnalyzerVersion}/cs/System.Text.Json.SourceGeneration.dll";
+                var path =
+                    $"Assets/Packages/{jsonPackageId.Id}.{jsonPackageId.Version}/analyzers/dotnet/roslyn{roslynAnalyzerVersion}/cs/System.Text.Json.SourceGeneration.dll";
                 Assert.That(path, Does.Exist.IgnoreDirectories);
                 var meta = (PluginImporter)AssetImporter.GetAtPath(path);
                 meta.SaveAndReimport();
 
 #if UNITY_2022_3_OR_NEWER
+
                 // somehow unity doesn't import the .dll on newer unity version
-                var postprocessor = new NugetAssetPostprocessor() { assetPath = path };
+                var postprocessor = new NugetAssetPostprocessor { assetPath = path };
                 postprocessor.GetType().GetMethod("OnPreprocessAsset", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(postprocessor, null);
 #endif
             }
@@ -178,7 +181,8 @@ public class NuGetTests
 
             foreach (var roslynAnalyzerVersion in roslynAnalyzerVersions)
             {
-                var path = $"Assets/Packages/{jsonPackageId.Id}.{jsonPackageId.Version}/analyzers/dotnet/roslyn{roslynAnalyzerVersion}/cs/System.Text.Json.SourceGeneration.dll";
+                var path =
+                    $"Assets/Packages/{jsonPackageId.Id}.{jsonPackageId.Version}/analyzers/dotnet/roslyn{roslynAnalyzerVersion}/cs/System.Text.Json.SourceGeneration.dll";
                 Assert.That(path, Does.Exist.IgnoreDirectories);
                 var meta = (PluginImporter)AssetImporter.GetAtPath(path);
                 Assert.IsNotNull(meta, "Get meta file");
@@ -187,11 +191,17 @@ public class NuGetTests
                 Assert.IsFalse(meta.GetCompatibleWithEditor(), "Expected to have set compatible with editor to false");
                 if (roslynAnalyzerVersion == expectedEnabledRoslynAnalyzerVersion)
                 {
-                    Assert.That(AssetDatabase.GetLabels(meta), Does.Contain("RoslynAnalyzer"), $"DLL of Roslyn analyzer version '{roslynAnalyzerVersion}' should have 'RoslynAnalyzer' label");
+                    Assert.That(
+                        AssetDatabase.GetLabels(meta),
+                        Does.Contain("RoslynAnalyzer"),
+                        $"DLL of Roslyn analyzer version '{roslynAnalyzerVersion}' should have 'RoslynAnalyzer' label");
                 }
                 else
                 {
-                    Assert.That(AssetDatabase.GetLabels(meta), Does.Not.Contain("RoslynAnalyzer"), $"DLL of Roslyn analyzer version '{roslynAnalyzerVersion}' should not have 'RoslynAnalyzer' label");
+                    Assert.That(
+                        AssetDatabase.GetLabels(meta),
+                        Does.Not.Contain("RoslynAnalyzer"),
+                        $"DLL of Roslyn analyzer version '{roslynAnalyzerVersion}' should not have 'RoslynAnalyzer' label");
                 }
             }
         }

--- a/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
+++ b/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
@@ -255,7 +255,9 @@ namespace NugetForUnity
                 else
                 {
                     var versionPrefixIndex = assetPath.IndexOf(AnalyzersRoslynVersionsFolderName, StringComparison.Ordinal);
-                    var analyzerVersionsRootDirectoryPath = Path.Combine(assetPath.Substring(0, versionPrefixIndex), AnalyzersRoslynVersionsFolderName);
+                    var analyzerVersionsRootDirectoryPath = Path.Combine(
+                        assetPath.Substring(0, versionPrefixIndex),
+                        AnalyzersRoslynVersionsFolderName);
                     var analyzersFolders = Directory.EnumerateDirectories(analyzerVersionsRootDirectoryPath);
                     var allEnabledRoslynVersions = analyzersFolders.Select(GetRoslynVersionNumberFromAnalyzerPath)
                         .Where(version => version != null && version.CompareTo(maxSupportedRoslynVersion) <= 0)


### PR DESCRIPTION
update GitHub action to use newer versions of dependent actions
updated:
- `tj-actions/changed-files`
- `actions/upload-artifact`
- replace `Bhacaz/checkout-files` with sparse checkout from `actions/checkout`
- `actions/download-artifact`
- `actions/setup-dotnet`