### PR TITLE
allow explicitly defining target-framework

### DIFF
--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -83,6 +83,26 @@ public class NuGetTests
     }
 
     [Test]
+    public void InstallJsonWithTargetFrameworkOverwriteTest()
+    {
+        // install a specific version
+        var package = new PackageConfig
+        {
+            Id = "Newtonsoft.Json", Version = "13.0.3", IsManuallyInstalled = true, TargetFramework = "netstandard1.3",
+        };
+        InstalledPackagesManager.PackagesConfigFile.Packages.Add(package);
+        NugetPackageInstaller.InstallIdentifier(package);
+        Assert.IsTrue(InstalledPackagesManager.IsInstalled(package, false), "The package was NOT installed: {0} {1}", package.Id, package.Version);
+        var libraryDirectory = Path.Combine(
+            ConfigurationManager.NugetConfigFile.RepositoryPath,
+            $"{package.Id}.{package.Version}",
+            "lib",
+            "netstandard1.3");
+        Assert.That(libraryDirectory, Does.Exist.IgnoreFiles);
+        Assert.That(Directory.EnumerateFiles(libraryDirectory, "*.dll"), Is.Not.Empty);
+    }
+
+    [Test]
     public void InstallRoslynAnalyzerTest([Values] InstallMode installMode)
     {
         ConfigureNugetConfig(installMode);
@@ -755,7 +775,7 @@ public class NuGetTests
             var foundBestMatch = new List<string>();
             while (allFrameworks.Count > 0)
             {
-                var bestMatch = TargetFrameworkResolver.TryGetBestTargetFrameworkForCurrentSettings(allFrameworks);
+                var bestMatch = TargetFrameworkResolver.TryGetBestTargetFrameworkForCurrentSettings(allFrameworks, null);
                 foundBestMatch.Add(bestMatch);
                 var expectedMatchIndex = 0;
                 if (!useNetStandard)

--- a/src/NuGetForUnity/Editor/Configuration/PackageConfig.cs
+++ b/src/NuGetForUnity/Editor/Configuration/PackageConfig.cs
@@ -1,3 +1,4 @@
+﻿using JetBrains.Annotations;
 using NugetForUnity.Models;
 
 namespace NugetForUnity.Configuration
@@ -14,5 +15,12 @@ namespace NugetForUnity.Configuration
         ///     by Unity projects that explicitly list them inside there <c>*.asmdef</c> file.
         /// </summary>
         public bool AutoReferenced { get; set; } = true;
+
+        /// <summary>
+        ///     Gets or sets the configured target framework moniker that is used to install this NuGet package instead of
+        ///     automatically determining the best matching target framework from the Unity settings ('Api Compatibility Level').
+        /// </summary>
+        [CanBeNull]
+        public string TargetFramework { get; set; }
     }
 }

--- a/src/NuGetForUnity/Editor/InstalledPackagesManager.cs
+++ b/src/NuGetForUnity/Editor/InstalledPackagesManager.cs
@@ -78,7 +78,7 @@ namespace NugetForUnity
         [CanBeNull]
         internal static PackageConfig GetPackageConfigurationById([NotNull] string packageIdentifier)
         {
-            return PackagesConfigFile.Packages.Find(pkg => string.Equals(pkg.Id, packageIdentifier, StringComparison.OrdinalIgnoreCase));
+            return PackagesConfigFile.GetPackageConfigurationById(packageIdentifier);
         }
 
         /// <summary>
@@ -129,10 +129,13 @@ namespace NugetForUnity
         ///     Adds the package to the 'packages.config' file.
         /// </summary>
         /// <param name="package">The package to add.</param>
-        internal static void AddPackageToConfig([NotNull] INugetPackage package)
+        /// <returns>The newly added or allready existing config entry from the packages.config file.</returns>
+        [NotNull]
+        internal static PackageConfig AddPackageToConfig([NotNull] INugetPackage package)
         {
-            PackagesConfigFile.AddPackage(package);
+            var packageConfig = PackagesConfigFile.AddPackage(package);
             PackagesConfigFile.Save();
+            return packageConfig;
         }
 
         /// <summary>

--- a/src/NuGetForUnity/Editor/Models/NugetPackageV2Base.cs
+++ b/src/NuGetForUnity/Editor/Models/NugetPackageV2Base.cs
@@ -146,8 +146,10 @@ namespace NugetForUnity.Models
             {
                 if (currentFrameworkDependencies == null)
                 {
-                    currentFrameworkDependencies =
-                        TargetFrameworkResolver.GetBestDependencyFrameworkGroupForCurrentSettings(Dependencies).Dependencies;
+                    currentFrameworkDependencies = TargetFrameworkResolver.GetBestDependencyFrameworkGroupForCurrentSettings(
+                            Dependencies,
+                            InstalledPackagesManager.GetPackageConfigurationById(Id)?.TargetFramework)
+                        .Dependencies;
                 }
 
                 return currentFrameworkDependencies;

--- a/src/NuGetForUnity/Editor/Models/NugetPackageV3.cs
+++ b/src/NuGetForUnity/Editor/Models/NugetPackageV3.cs
@@ -196,8 +196,10 @@ namespace NugetForUnity.Models
             {
                 if (currentFrameworkDependencies == null)
                 {
-                    currentFrameworkDependencies =
-                        TargetFrameworkResolver.GetBestDependencyFrameworkGroupForCurrentSettings(Dependencies).Dependencies;
+                    currentFrameworkDependencies = TargetFrameworkResolver.GetBestDependencyFrameworkGroupForCurrentSettings(
+                            Dependencies,
+                            InstalledPackagesManager.GetPackageConfigurationById(Id)?.TargetFramework)
+                        .Dependencies;
                 }
 
                 return currentFrameworkDependencies;

--- a/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
+++ b/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
@@ -128,8 +128,7 @@ namespace NugetForUnity
             var assetPathComponents = GetPathComponents(assetPathRelativeToRepository);
             var packageNameParts = assetPathComponents.Length > 0 ? assetPathComponents[0].Split('.') : Array.Empty<string>();
             var packageName = string.Join(".", packageNameParts.TakeWhile(part => !part.All(char.IsDigit)));
-            var packageConfig = InstalledPackagesManager.PackagesConfigFile.Packages.Find(
-                packageSettings => packageSettings.Id.Equals(packageName, StringComparison.OrdinalIgnoreCase));
+            var packageConfig = InstalledPackagesManager.PackagesConfigFile.GetPackageConfigurationById(packageName);
 
             if (!GetPluginImporter(projectRelativeAssetPath, out var plugin))
             {

--- a/src/NuGetForUnity/Editor/Ui/NuspecEditor.cs
+++ b/src/NuGetForUnity/Editor/Ui/NuspecEditor.cs
@@ -209,7 +209,7 @@ namespace NugetForUnity.Ui
 
                     // display the dependencies
                     NugetPackageIdentifier toDelete = null;
-                    var nuspecFrameworkGroup = TargetFrameworkResolver.GetBestDependencyFrameworkGroupForCurrentSettings(nuspec);
+                    var nuspecFrameworkGroup = TargetFrameworkResolver.GetBestDependencyFrameworkGroupForCurrentSettings(nuspec, null);
                     foreach (var dependency in nuspecFrameworkGroup.Dependencies.Cast<NugetPackageIdentifier>())
                     {
                         EditorGUILayout.BeginHorizontal();


### PR DESCRIPTION
allow explicitly defining the target-framework used to install a NuGet package
to use this feature add the `targetFramework` attribute to the `package` inside the `packages.config` e.g.:
`<package id="LiteDB" version="5.0.16" manuallyInstalled="true"  targetFramework="netstandard2.0" />`

fixes #621 and #603