### PR TITLE
Add option to prefer .NET Standard over .NET Framework as TargetFramework

### DIFF
--- a/src/NuGetForUnity/Editor/Configuration/ConfigurationManager.cs
+++ b/src/NuGetForUnity/Editor/Configuration/ConfigurationManager.cs
@@ -87,6 +87,11 @@ namespace NugetForUnity.Configuration
         internal static bool IsVerboseLoggingEnabled => nugetConfigFile?.Verbose ?? false;
 
         /// <summary>
+        ///     Gets the value indicating whether .NET Standard is preferred over .NET Framework as the TargetFramework.
+        /// </summary>
+        internal static bool PreferNetStandardOverNetFramework => nugetConfigFile?.PreferNetStandardOverNetFramework ?? false;
+
+        /// <summary>
         ///     Gets the <see cref="INugetPackageSource" /> to use.
         /// </summary>
         [NotNull]

--- a/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
@@ -52,6 +52,8 @@ namespace NugetForUnity.Configuration
 
         private const string PackagesConfigDirectoryPathConfigKey = "PackagesConfigDirectoryPath";
 
+        private const string PreferNetStandardOverNetFrameworkConfigKey = "PreferNetStandardOverNetFramework";
+
         private const string ProtocolVersionAttributeName = "protocolVersion";
 
         private const string PasswordAttributeName = "password";
@@ -185,6 +187,11 @@ namespace NugetForUnity.Configuration
         ///     Gets or sets the timeout in seconds used for all web requests to NuGet sources.
         /// </summary>
         public int RequestTimeoutSeconds { get; set; } = DefaultRequestTimeout;
+
+        /// <summary>
+        ///     Gets or sets the value indicating whether .NET Standard is preferred over .NET Framework as the TargetFramework.
+        /// </summary>
+        public bool PreferNetStandardOverNetFramework { get; set; }
 
         /// <summary>
         ///     Gets the value that tells the system how to determine where the packages are to be installed and configurations are to be stored.
@@ -380,6 +387,10 @@ namespace NugetForUnity.Configuration
                 {
                     configFile.RelativePackagesConfigDirectoryPath = value;
                 }
+                else if (string.Equals(key, PreferNetStandardOverNetFrameworkConfigKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    configFile.PreferNetStandardOverNetFramework = bool.Parse(value);
+                }
             }
 
             return configFile;
@@ -559,6 +570,14 @@ namespace NugetForUnity.Configuration
                 addElement = new XElement("add");
                 addElement.Add(new XAttribute("key", RequestTimeoutSecondsConfigKey));
                 addElement.Add(new XAttribute("value", RequestTimeoutSeconds));
+                config.Add(addElement);
+            }
+
+            if (PreferNetStandardOverNetFramework)
+            {
+                addElement = new XElement("add");
+                addElement.Add(new XAttribute("key", PreferNetStandardOverNetFrameworkConfigKey));
+                addElement.Add(new XAttribute("value", PreferNetStandardOverNetFramework.ToString().ToLowerInvariant()));
                 config.Add(addElement);
             }
 

--- a/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
@@ -419,6 +419,7 @@ namespace NugetForUnity.Configuration
     <add key=""repositoryPath"" value=""./Packages"" />
     <add key=""PackagesConfigDirectoryPath"" value=""."" />
     <add key=""slimRestore"" value=""true"" />
+    <add key=""PreferNetStandardOverNetFramework"" value=""true"" />
   </config>
 </configuration>";
 

--- a/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
+++ b/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
@@ -109,82 +109,27 @@ namespace NugetForUnity
 
         // Almost same as PrioritizedTargetFrameworks, but it prefers .NET Standard 2.x over .NET Framework.
         [NotNull]
-        private static readonly TargetFrameworkSupport[] PrioritizedTargetFrameworksPreferNetStandard20Or21 =
+        private static readonly TargetFrameworkSupport[] PrioritizedTargetFrameworksPreferNetStandard20Or21;
+
+        static TargetFrameworkResolver()
         {
-            new TargetFrameworkSupport("unity"),
-
-            // Prefer .NET Standard 2.x over .NET Framework
-            new TargetFrameworkSupport(
-                "netstandard21",
-                new UnityVersion(2021, 2, 0, 'f', 0),
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport(
-                "netstandard20",
-                null,
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-
-            // .net framework (as we don't support unity < 2018 we can expect that at least .net framework 4.4 is supported)
-            new TargetFrameworkSupport("net48", new UnityVersion(2021, 2, 0, 'f', 0), DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net472", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net471", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net47", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net462", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net461", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net46", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net452", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net451", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net45", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net403", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net40", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net4", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net35-unity full v35", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net35-unity subset v35", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net35", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net20", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport("net11", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
-
-            // .net standard
-            new TargetFrameworkSupport(
-                "netstandard16",
-                null,
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport(
-                "netstandard15",
-                null,
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport(
-                "netstandard14",
-                null,
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport(
-                "netstandard13",
-                null,
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport(
-                "netstandard12",
-                null,
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport(
-                "netstandard11",
-                null,
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-            new TargetFrameworkSupport(
-                "netstandard10",
-                null,
-                DotnetVersionCompatibilityLevel.NetStandard20Or21,
-                DotnetVersionCompatibilityLevel.NetFramework46Or48),
-
-            // fallback if there is one with empty string
-            new TargetFrameworkSupport(string.Empty),
-        };
+            PrioritizedTargetFrameworksPreferNetStandard20Or21 = PrioritizedTargetFrameworks.OrderBy(
+                    framework =>
+                    {
+                        switch (framework.Name)
+                        {
+                            case "unity":
+                                return 1; // keep it first
+                            case "netstandard21":
+                                return 2; // Prefer .NET Standard 2.x over .NET Framework
+                            case "netstandard20":
+                                return 3; // Prefer .NET Standard 2.x over .NET Framework
+                            default:
+                                return 4; // keep the rest in the same order as before
+                        }
+                    })
+                .ToArray();
+        }
 
         /// <summary>
         ///     Gets the <see cref="ApiCompatibilityLevel" /> of the current selected build target.

--- a/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
+++ b/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using NugetForUnity.Configuration;
 using NugetForUnity.Models;
 using UnityEditor;
 
@@ -66,6 +67,85 @@ namespace NugetForUnity
                 null,
                 DotnetVersionCompatibilityLevel.NetStandard20Or21,
                 DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard16",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard15",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard14",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard13",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard12",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard11",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard10",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+
+            // fallback if there is one with empty string
+            new TargetFrameworkSupport(string.Empty),
+        };
+
+        // Almost same as PrioritizedTargetFrameworks, but it prefers .NET Standard 2.x over .NET Framework.
+        [NotNull]
+        private static readonly TargetFrameworkSupport[] PrioritizedTargetFrameworksPreferNetStandard20Or21 =
+        {
+            new TargetFrameworkSupport("unity"),
+
+            // Prefer .NET Standard 2.x over .NET Framework
+            new TargetFrameworkSupport(
+                "netstandard21",
+                new UnityVersion(2021, 2, 0, 'f', 0),
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard20",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+
+            // .net framework (as we don't support unity < 2018 we can expect that at least .net framework 4.4 is supported)
+            new TargetFrameworkSupport("net48", new UnityVersion(2021, 2, 0, 'f', 0), DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net472", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net471", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net47", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net462", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net461", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net46", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net452", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net451", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net45", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net403", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net40", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net4", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net35-unity full v35", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net35-unity subset v35", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net35", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net20", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net11", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+
+            // .net standard
             new TargetFrameworkSupport(
                 "netstandard16",
                 null,
@@ -191,7 +271,10 @@ namespace NugetForUnity
 
             var currentDotnetVersion = CurrentBuildTargetDotnetVersionCompatibilityLevel;
             var currentUnityVersion = UnityVersion.Current;
-            foreach (var targetFrameworkSupport in PrioritizedTargetFrameworks)
+            var prioritizedTargetFrameworks = ConfigurationManager.PreferNetStandardOverNetFramework ?
+                PrioritizedTargetFrameworksPreferNetStandard20Or21 :
+                PrioritizedTargetFrameworks;
+            foreach (var targetFrameworkSupport in prioritizedTargetFrameworks)
             {
                 if (targetFrameworkSupport.SupportedDotnetVersions.Length != 0 &&
                     !targetFrameworkSupport.SupportedDotnetVersions.Contains(currentDotnetVersion))

--- a/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
@@ -112,7 +112,7 @@ namespace NugetForUnity.Ui
             var sourcePathChangedThisFrame = false;
             var needsAssetRefresh = false;
 
-            var biggestLabelSize = EditorStyles.label.CalcSize(new GUIContent("Prefer .NET Standard as TargetFramework")).x;
+            var biggestLabelSize = EditorStyles.label.CalcSize(new GUIContent("Prefer .NET Standard dependencies over .NET Framework")).x;
             EditorGUIUtility.labelWidth = biggestLabelSize;
             EditorGUILayout.LabelField($"Version: {NuGetForUnityVersion}");
 
@@ -244,11 +244,22 @@ namespace NugetForUnity.Ui
                 }
             }
 
-            var preferNetStandardOverNetFramework = EditorGUILayout.Toggle("Prefer .NET Standard as TargetFramework", ConfigurationManager.NugetConfigFile.PreferNetStandardOverNetFramework);
+            var preferNetStandardOverNetFramework = EditorGUILayout.Toggle(
+                new GUIContent(
+                    "Prefer .NET Standard dependencies over .NET Framework",
+                    "If a nuget package contains DLL's for .NET Framework an .NET Standard the .NET Standard DLL's are preferred."),
+                ConfigurationManager.NugetConfigFile.PreferNetStandardOverNetFramework);
             if (preferNetStandardOverNetFramework != ConfigurationManager.NugetConfigFile.PreferNetStandardOverNetFramework)
             {
                 preferencesChangedThisFrame = true;
                 ConfigurationManager.NugetConfigFile.PreferNetStandardOverNetFramework = preferNetStandardOverNetFramework;
+            }
+
+            if (TargetFrameworkResolver.CurrentBuildTargetApiCompatibilityLevel.Value == ApiCompatibilityLevel.NET_Standard_2_0)
+            {
+                EditorGUILayout.HelpBox(
+                    "The prefer .NET Standard setting has no effect as you have set the API compatibility level to .NET Standard so .NET Standard will always be preferred, as it is the only supported.",
+                    MessageType.Info);
             }
 
             var requestTimeout = EditorGUILayout.IntField(

--- a/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
@@ -112,7 +112,7 @@ namespace NugetForUnity.Ui
             var sourcePathChangedThisFrame = false;
             var needsAssetRefresh = false;
 
-            var biggestLabelSize = EditorStyles.label.CalcSize(new GUIContent("Request Timeout in seconds")).x;
+            var biggestLabelSize = EditorStyles.label.CalcSize(new GUIContent("Prefer .NET Standard as TargetFramework")).x;
             EditorGUIUtility.labelWidth = biggestLabelSize;
             EditorGUILayout.LabelField($"Version: {NuGetForUnityVersion}");
 
@@ -242,6 +242,13 @@ namespace NugetForUnity.Ui
                         "The packages.config is placed outside of Assets folder, this disables the functionality of automatically restoring packages if the file is changed on the disk.",
                         MessageType.Warning);
                 }
+            }
+
+            var preferNetStandardOverNetFramework = EditorGUILayout.Toggle("Prefer .NET Standard as TargetFramework", ConfigurationManager.NugetConfigFile.PreferNetStandardOverNetFramework);
+            if (preferNetStandardOverNetFramework != ConfigurationManager.NugetConfigFile.PreferNetStandardOverNetFramework)
+            {
+                preferencesChangedThisFrame = true;
+                ConfigurationManager.NugetConfigFile.PreferNetStandardOverNetFramework = preferNetStandardOverNetFramework;
             }
 
             var requestTimeout = EditorGUILayout.IntField(


### PR DESCRIPTION
This PR adds the option to prioritize .NET Standard over .NET Framework as TargetFramework.

![image](https://github.com/GlitchEnzo/NuGetForUnity/assets/9012/c8c09514-1389-4200-b94a-754aff077ef7)

## Background
As written in Issue https://github.com/GlitchEnzo/NuGetForUnity/issues/621, the currently supported Unity differs from the original .NET Framework, possessing an API surface of .NET Standard 2.1, even when the API Compatibility Level is set to `.NET Framework`.

Due to [Unity's .NET Framework a strange and unique combination of .NET Framework 4.8 and .NET Standard 2.1](https://docs.unity3d.com/2022.3/Documentation/Manual/dotnetProfileSupport.html), various issues arise when an assembly targeted at `net46x` is installed.

For example, `Microsoft.Bcl.AsyncInterfaces` for `net462` (.NET Framework) includes `System.IAsyncDisposable`, which is provided as an in-built API in .NET Standard 2.1. As a result, installing it in a .NET Framework Unity project causes the following compile error:

```
error CS0433: The type 'IAsyncDisposable' exists in both 'Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' and 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
```

Additionally, `Grpc.Net.Client` has libraries for `net461` that are not compatible with .NET Standard 2.x and do not work, leading to unnecessary dependencies being installed.

To address this issue, https://github.com/GlitchEnzo/NuGetForUnity/pull/630 made it possible to specify `targetFramework` in the packages.config, but this does not affect transitive dependencies. In some cases, you need to specify this for each implicitly installed package. (Example: [Our project's installation of Grpc.Net.Client in package.json](https://github.com/Cysharp/MagicOnion/blob/da3b2db502a544e9afbc728c5fc47b9f9ef30b53/samples/ChatApp/ChatApp.Unity/Assets/packages.config))

Hence, I added an option to always prioritize .NET Standard 2.x over .NET Framework as the target framework choice in the project.

## Remarks
<del>The option added by this PR is **turned off by default**, but in my opinion, making this behavior of prioritizing .NET Standard the default could be appropriate.</del>

The option added by this PR is **turned off by default**. This means that the behaviour does not change in existing projects. But it **turned on by default** when NuGet.config is newly created.

I believe that libraries built for .NET Standard 2.x, especially 2.1, are more modern than those built specifically for the .NET Framework. In Unity, if `API Compatibility Level` changes from `.NET Standard` to `.NET Framework`, the legacy API set could be used instead of the libraries that could be used in .NET Standard 2.1, but I don't think any developer would like that.