### PR TITLE
fix duplicate content

### DIFF
--- a/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
+++ b/src/NuGetForUnity/Editor/NugetPackageInstaller.cs
@@ -166,6 +166,18 @@ namespace NugetForUnity
                     // unzip the package
                     using (var zip = ZipFile.OpenRead(cachedPackagePath))
                     {
+                        // check if nuget package has contentFiles folder
+                        const string contentFilesDirectoryName = "contentFiles/";
+                        var hasContentFilesFolder = false;
+                        foreach (var entry in zip.Entries)
+                        {
+                            if (entry.FullName.EndsWith("/") && entry.FullName.Equals(contentFilesDirectoryName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                hasContentFilesFolder = true;
+                                break;
+                            }
+                        }
+
                         var libs = new Dictionary<string, List<ZipArchiveEntry>>();
                         var csFiles = new Dictionary<string, List<ZipArchiveEntry>>();
                         var anyFiles = new Dictionary<string, List<ZipArchiveEntry>>();
@@ -179,7 +191,7 @@ namespace NugetForUnity
                                 continue;
                             }
 
-                            if (PackageContentManager.ShouldSkipUnpackingOnPath(entryFullName))
+                            if (PackageContentManager.ShouldSkipUnpackingOnPath(entryFullName, hasContentFilesFolder))
                             {
                                 continue;
                             }
@@ -206,7 +218,6 @@ namespace NugetForUnity
 
                             // in case this is a source code package, we want to collect all its entries that have 'cs' or 'any' set as language
                             // and their frameworks so we can get the best framework later
-                            const string contentFilesDirectoryName = "contentFiles/";
                             if (entryFullName.StartsWith(contentFilesDirectoryName, StringComparison.Ordinal))
                             {
                                 // Folder structure for source code packages:

--- a/src/NuGetForUnity/Editor/PackageContentManager.cs
+++ b/src/NuGetForUnity/Editor/PackageContentManager.cs
@@ -109,14 +109,24 @@ namespace NugetForUnity
         ///     The path of the file inside the .nupkg it is relative starting from the package route. It always uses '/' as a slash on all
         ///     platforms.
         /// </param>
+        /// <param name="hasContentFilesFolder">
+        ///     The package has contentfiles folder, we need to omit content folder it exist. Because some nuget package has both folder to
+        ///     to support old version and new version of nuget.
+        /// </param>
         /// <returns>True if the file can be skipped, is not needed.</returns>
-        internal static bool ShouldSkipUnpackingOnPath([NotNull] string path)
+        internal static bool ShouldSkipUnpackingOnPath([NotNull] string path, bool hasContentFilesFolder)
         {
             if (path.EndsWith("/"))
             {
                 // We do not want to extract empty directory entries. If there are empty directories within the .nupkg, we
                 // expect them to have a file named '_._' in them that indicates that it should be extracted, usually as a
                 // compatibility indicator (https://stackoverflow.com/questions/36338052/what-do-files-mean-in-nuget-packages)
+                return true;
+            }
+
+            // skip content folder when it has contentFiles folder
+            if (hasContentFilesFolder && (path.StartsWith("content/", StringComparison.Ordinal) || path.Contains("/content/")))
+            {
                 return true;
             }
 


### PR DESCRIPTION
https://stackoverflow.com/questions/47468941/prevent-duplicating-files-in-nuget-content-and-contentfiles-folders

Test NuGetPackage: `MongoDB.Libmongocrypt`.

as far as i know, that a nuget package may have both `content` and `contentFiles` folder and the contain the same files.

from now on, i change the code to omit `content` folder when it has `contentFiles` and it works for my package.