### PR TITLE
Build net7.0- and net8.0-compatible versions of NuGetForUnity.CLI

### DIFF
--- a/src/NuGetForUnity.Cli/NuGetForUnity.Cli.csproj
+++ b/src/NuGetForUnity.Cli/NuGetForUnity.Cli.csproj
@@ -3,7 +3,7 @@
         <OutputType>Exe</OutputType>
         <RootNamespace>NuGetForUnity.Cli</RootNamespace>
         <AssemblyName>NuGetForUnity.Cli</AssemblyName>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>nugetforunity</ToolCommandName>


### PR DESCRIPTION
Some CI environments, such as Unity Cloud Build, only provide the dotnet 7.0 runtime, making a net8.0-targeted `NuGetForUnity.Cli` build unusable in them. With this change the `NuGetForUnity.Cli.nupkg` output by `dotnet pack` contains builds for both runtime versions. 

I've confirmed that this fixes the runtime version errors the net8.0-only builds was causing in Unity Cloud Build.