### PR TITLE
Allow netstandard0.0 as target framework

### DIFF
--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -585,6 +585,21 @@ public class NuGetTests
     }
 
     [Test]
+    public void InstallPackageWith00DependencyTest()
+    {
+        ConfigureNugetConfig(InstallMode.ApiV3Only);
+
+        var packageWith00Dependency = new NugetPackageIdentifier("Microsoft.ML.OnnxRuntime", "1.19.2") { IsManuallyInstalled = true };
+        var expectedDependency = new NugetPackageIdentifier("Microsoft.ML.OnnxRuntime.Managed", "1.19.2");
+
+        NugetPackageInstaller.InstallIdentifier(packageWith00Dependency);
+
+        // Microsoft.ML.OnnxRuntime depends on Microsoft.ML.OnnxRuntime.Managed, so they should both be installed
+        Assert.That(InstalledPackagesManager.InstalledPackages, Does.Contain(packageWith00Dependency));
+        Assert.That(InstalledPackagesManager.InstalledPackages, Does.Contain(expectedDependency));
+    }
+
+    [Test]
     [TestCase("1.0.0-rc1", "1.0.0")]
     [TestCase("1.0.0-rc1", "1.0.0-rc2")]
     [TestCase("1.2.3", "1.2.4")]

--- a/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
+++ b/src/NuGetForUnity/Editor/TargetFrameworkResolver.cs
@@ -55,6 +55,7 @@ namespace NugetForUnity
             new TargetFrameworkSupport("net35", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
             new TargetFrameworkSupport("net20", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
             new TargetFrameworkSupport("net11", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport("net00", null, DotnetVersionCompatibilityLevel.NetFramework46Or48),
 
             // .net standard
             new TargetFrameworkSupport(
@@ -99,6 +100,11 @@ namespace NugetForUnity
                 DotnetVersionCompatibilityLevel.NetFramework46Or48),
             new TargetFrameworkSupport(
                 "netstandard10",
+                null,
+                DotnetVersionCompatibilityLevel.NetStandard20Or21,
+                DotnetVersionCompatibilityLevel.NetFramework46Or48),
+            new TargetFrameworkSupport(
+                "netstandard00",
                 null,
                 DotnetVersionCompatibilityLevel.NetStandard20Or21,
                 DotnetVersionCompatibilityLevel.NetFramework46Or48),


### PR DESCRIPTION
allow installing packages that reference netstandard0.0 as framework
E.g. [Microsoft.ML.OnnxRuntime](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime#dependencies-body-tab) uses this beaus it just references the real C# package as a dependency