### PR TITLE
add net 9 target to NuGetForUnity.Cli

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,9 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: |
+            "8.0.x"
+            "9.0.x"
 
       - name: Build and pack .NET Core Global Tool
         run: >-

--- a/src/NuGetForUnity.Cli/NuGetForUnity.Cli.csproj
+++ b/src/NuGetForUnity.Cli/NuGetForUnity.Cli.csproj
@@ -3,7 +3,7 @@
         <OutputType>Exe</OutputType>
         <RootNamespace>NuGetForUnity.Cli</RootNamespace>
         <AssemblyName>NuGetForUnity.Cli</AssemblyName>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>nugetforunity</ToolCommandName>
@@ -34,8 +34,8 @@ e.g. the import settings of the DLL's are changed to comply with Unity.
         <Compile Remove="..\NuGetForUnity\Editor\UnityPreImportedLibraryResolver.cs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
-        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+        <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     </ItemGroup>
     <ItemGroup>
         <Reference Include="NuGetForUnity.PluginAPI">

--- a/src/TestProjects/ImportAndUseNuGetPackages/Assets/packages.config
+++ b/src/TestProjects/ImportAndUseNuGetPackages/Assets/packages.config
@@ -6,6 +6,6 @@
   <package id="System.Numerics.Vectors" version="4.5.0" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />
   <package id="System.Text.Encodings.Web" version="7.0.0" />
-  <package id="System.Text.Json" version="7.0.1" manuallyInstalled="true" />
+  <package id="System.Text.Json" version="9.0.0" manuallyInstalled="true" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" />
 </packages>


### PR DESCRIPTION
- add net 9 target to `NuGetForUnity.Cli`
- update used `System.Text.Json` version to prevent security warning