### PR TITLE
add setting to disable credential provider per package source

### DIFF
--- a/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
+++ b/src/NuGetForUnity/Editor/Configuration/NugetConfigFile.cs
@@ -58,6 +58,8 @@ namespace NugetForUnity.Configuration
 
         private const string ProtocolVersionAttributeName = "protocolVersion";
 
+        private const string EnableCredentialProviderAttributeName = "enableCredentialProvider";
+
         private const string PasswordAttributeName = "password";
 
         private const string UpdateSearchBatchSizeAttributeName = "updateSearchBatchSize";
@@ -392,7 +394,7 @@ namespace NugetForUnity.Configuration
 <configuration>
   <packageSources>
     <clear />
-    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" />
+    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" enableCredentialProvider=""false"" />
   </packageSources>
   <disabledPackageSources />
   <activePackageSource>
@@ -436,6 +438,12 @@ namespace NugetForUnity.Configuration
                 if (!string.IsNullOrEmpty(source.SavedProtocolVersion))
                 {
                     addElement.Add(new XAttribute(ProtocolVersionAttributeName, source.SavedProtocolVersion));
+                }
+
+                if (!source.EnableCredentialProvider)
+                {
+                    addElement.Add(
+                        new XAttribute(EnableCredentialProviderAttributeName, source.EnableCredentialProvider.ToString().ToLowerInvariant()));
                 }
 
                 if (source is NugetPackageSourceV3 sourceV3)

--- a/src/NuGetForUnity/Editor/Helper/CredentialProviderHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/CredentialProviderHelper.cs
@@ -60,8 +60,15 @@ namespace NugetForUnity.Helper
             feedUri = GetTruncatedFeedUri(feedUri);
             if (!CachedCredentialsByFeedUri.TryGetValue(feedUri, out var response))
             {
-                response = GetCredentialFromProvider_Uncached(feedUri, true);
-                CachedCredentialsByFeedUri[feedUri] = response;
+                try
+                {
+                    response = GetCredentialFromProvider_Uncached(feedUri, true);
+                    CachedCredentialsByFeedUri[feedUri] = response;
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogErrorFormat("Failed to get packages source credentials from the credential provider. Error: {0}", exception);
+                }
             }
 
             if (response == null)
@@ -356,9 +363,10 @@ namespace NugetForUnity.Helper
             [CanBeNull]
             public string Password;
 
-            // Ignore Spelling: Username
             [CanBeNull]
             public string Username;
+
+            // Ignore Spelling: Username
         }
 #pragma warning restore 0649 // CS0649: Field 'field' is never assigned to, and will always have its default value 'value'
     }

--- a/src/NuGetForUnity/Editor/Helper/WebRequestHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/WebRequestHelper.cs
@@ -20,9 +20,15 @@ namespace NugetForUnity.Helper
         /// <param name="userName">UserName that will be passed in the Authorization header or the request. If null, authorization is omitted.</param>
         /// <param name="password">Password that will be passed in the Authorization header or the request. If null, authorization is omitted.</param>
         /// <param name="timeOut">Timeout in milliseconds or null to use the default timeout values of HttpWebRequest.</param>
+        /// <param name="enableCredentialProvider">If true we invoke credential providers found on the system to receive the credentials for the NuGet feed.</param>
         /// <returns>Stream containing the result.</returns>
         [NotNull]
-        internal static Stream RequestUrl([NotNull] string url, [CanBeNull] string userName, [CanBeNull] string password, int? timeOut)
+        internal static Stream RequestUrl(
+            [NotNull] string url,
+            [CanBeNull] string userName,
+            [CanBeNull] string password,
+            int? timeOut,
+            bool enableCredentialProvider)
         {
             // Mono doesn't have a Certificate Authority, so we have to provide all validation manually. Currently just accept anything.
             // See here: http://stackoverflow.com/questions/4926676/mono-webrequest-fails-with-https
@@ -35,7 +41,7 @@ namespace NugetForUnity.Helper
                 getRequest.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.None;
                 getRequest.Timeout = timeOut ?? ConfigurationManager.NugetConfigFile.RequestTimeoutSeconds * 1000;
 
-                if (string.IsNullOrEmpty(password))
+                if (string.IsNullOrEmpty(password) && enableCredentialProvider)
                 {
                     var credentials = CredentialProviderHelper.GetCredentialFromProvider(getRequest.RequestUri);
                     if (credentials.HasValue)

--- a/src/NuGetForUnity/Editor/PackageSource/INugetPackageSource.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/INugetPackageSource.cs
@@ -65,6 +65,13 @@ namespace NugetForUnity.PackageSource
         bool CredentialsStoredInExternalFile { get; set; }
 
         /// <summary>
+        ///     Gets or sets a value indicating whether to invoke credential providers found on the system to
+        ///     receive the credentials for the NuGet feed. See here for more info on NuGet Credential Providers:
+        ///     https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-exe-credential-providers.
+        /// </summary>
+        bool EnableCredentialProvider { get; set; }
+
+        /// <summary>
         ///     Download the .nupkg file and store it inside a file at <paramref name="outputFilePath" />.
         /// </summary>
         /// <param name="package">The package to download its .nupkg from.</param>

--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -1,5 +1,7 @@
 ﻿#pragma warning disable SA1512,SA1124 // Single-line comments should not be followed by blank line
 
+#region No ReShaper
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -17,8 +19,6 @@ using NugetForUnity.Helper;
 using NugetForUnity.Models;
 using UnityEditor;
 using UnityEngine;
-
-#region No ReShaper
 
 // ReSharper disable All
 // needed because 'JetBrains.Annotations.NotNull' and 'System.Diagnostics.CodeAnalysis.NotNull' collide if this file is compiled with a never version of Unity / C#
@@ -778,7 +778,7 @@ namespace NugetForUnity.PackageSource
             var password = packageSource.ExpandedPassword;
             var userName = packageSource.ExpandedUserName;
 
-            if (string.IsNullOrEmpty(password))
+            if (string.IsNullOrEmpty(password) && packageSource.EnableCredentialProvider)
             {
                 var creds = CredentialProviderHelper.GetCredentialFromProvider(apiIndexJsonUrl);
                 if (creds.HasValue)

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceCombined.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceCombined.cs
@@ -119,6 +119,17 @@ namespace NugetForUnity.PackageSource
         }
 
         /// <inheritdoc />
+        public bool EnableCredentialProvider
+        {
+            get => false;
+
+            set
+            {
+                // multiple sources can't have credentials
+            }
+        }
+
+        /// <inheritdoc />
         public List<INugetPackage> FindPackagesById(INugetPackageIdentifier package)
         {
             var activeSourcesCount = packageSources.Count(source => source.IsEnabled);

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceLocal.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceLocal.cs
@@ -107,6 +107,17 @@ namespace NugetForUnity.PackageSource
             }
         }
 
+        /// <inheritdoc />
+        public bool EnableCredentialProvider
+        {
+            get => false;
+
+            set
+            {
+                // multiple sources can't have credentials
+            }
+        }
+
         /// <summary>
         ///     Gets path, with the values of environment variables expanded.
         /// </summary>

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceLocal.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceLocal.cs
@@ -44,7 +44,7 @@ namespace NugetForUnity.PackageSource
 
             set
             {
-                // multiple sources can't have protocol version
+                // local sources can't have protocol version
             }
         }
 
@@ -114,7 +114,7 @@ namespace NugetForUnity.PackageSource
 
             set
             {
-                // multiple sources can't have credentials
+                // local sources can't have credentials
             }
         }
 

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV2.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV2.cs
@@ -91,6 +91,10 @@ namespace NugetForUnity.PackageSource
         [field: SerializeField]
         public bool CredentialsStoredInExternalFile { get; set; }
 
+        /// <inheritdoc />
+        [field: SerializeField]
+        public bool EnableCredentialProvider { get; set; } = true;
+
         /// <summary>
         ///     Gets password, with the values of environment variables expanded.
         /// </summary>
@@ -400,7 +404,7 @@ namespace NugetForUnity.PackageSource
                 throw new ArgumentNullException(nameof(downloadUrlHint));
             }
 
-            using (var objStream = WebRequestHelper.RequestUrl(downloadUrlHint, ExpandedUserName, ExpandedPassword, null))
+            using (var objStream = WebRequestHelper.RequestUrl(downloadUrlHint, ExpandedUserName, ExpandedPassword, null, EnableCredentialProvider))
             {
                 using (var fileStream = File.Create(outputFilePath))
                 {
@@ -486,7 +490,7 @@ namespace NugetForUnity.PackageSource
             stopwatch.Start();
 
             var packages = new List<INugetPackage>();
-            using (var responseStream = WebRequestHelper.RequestUrl(url, ExpandedUserName, ExpandedPassword, 10000))
+            using (var responseStream = WebRequestHelper.RequestUrl(url, ExpandedUserName, ExpandedPassword, 10000, EnableCredentialProvider))
             {
                 using (var streamReader = new StreamReader(responseStream))
                 {

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
@@ -147,6 +147,10 @@ namespace NugetForUnity.PackageSource
 
         /// <inheritdoc />
         [field: SerializeField]
+        public bool EnableCredentialProvider { get; set; } = true;
+
+        /// <inheritdoc />
+        [field: SerializeField]
         public bool IsEnabled { get; set; }
 
         /// <inheritdoc />

--- a/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
@@ -443,9 +443,9 @@ namespace NugetForUnity.Ui
                                 }
                             }
 
-                            const string useCredentialProviderToogleLable = "Use credential provider (if found)";
+                            const string useCredentialProviderToogleLabel = "Use credential provider (if found)";
                             biggestPackageSourceSectionLabelSize = biggestPackageSourceSectionLabelSize ??
-                                                                   EditorStyles.label.CalcSize(new GUIContent(useCredentialProviderToogleLable)).x;
+                                                                   EditorStyles.label.CalcSize(new GUIContent(useCredentialProviderToogleLabel)).x;
                             EditorGUIUtility.labelWidth = biggestPackageSourceSectionLabelSize.Value + LabelPading;
 
                             var currentForceUseApiV3 = source.SavedProtocolVersion?.Equals("3", StringComparison.Ordinal) == true;
@@ -501,7 +501,7 @@ namespace NugetForUnity.Ui
 
                                     var enableCredentialProvider = EditorGUILayout.Toggle(
                                         new GUIContent(
-                                            useCredentialProviderToogleLable,
+                                            useCredentialProviderToogleLabel,
                                             "Whether to call the credential providers found on the system to receive the credentials for the NuGet feed. See NuGet documentation for more info on NuGet Credential Providers: https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-exe-credential-providers."),
                                         source.EnableCredentialProvider);
                                     if (enableCredentialProvider != source.EnableCredentialProvider)

--- a/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetPreferences.cs
@@ -443,8 +443,9 @@ namespace NugetForUnity.Ui
                                 }
                             }
 
+                            const string useCredentialProviderToogleLable = "Use credential provider (if found)";
                             biggestPackageSourceSectionLabelSize = biggestPackageSourceSectionLabelSize ??
-                                                                   EditorStyles.label.CalcSize(new GUIContent("Force use API v3")).x;
+                                                                   EditorStyles.label.CalcSize(new GUIContent(useCredentialProviderToogleLable)).x;
                             EditorGUIUtility.labelWidth = biggestPackageSourceSectionLabelSize.Value + LabelPading;
 
                             var currentForceUseApiV3 = source.SavedProtocolVersion?.Equals("3", StringComparison.Ordinal) == true;
@@ -453,7 +454,7 @@ namespace NugetForUnity.Ui
                                 var forceUseApiV3 = EditorGUILayout.Toggle(
                                     new GUIContent(
                                         "Force use API v3",
-                                        "Normally the API version is autodetect. " +
+                                        "Normally the API version is automatically detected. " +
                                         "It defaults to version \"2\" when not pointing to a package source URL ending in .json (e.g. https://api.nuget.org/v3/index.json). " +
                                         "So if a package source uses API v3 but the URL doesn't end in .json you need to enable this setting (e.g. needed when using 'Aritfactory')."),
                                     currentForceUseApiV3);
@@ -497,6 +498,17 @@ namespace NugetForUnity.Ui
                                 else
                                 {
                                     source.SavedUserName = null;
+
+                                    var enableCredentialProvider = EditorGUILayout.Toggle(
+                                        new GUIContent(
+                                            useCredentialProviderToogleLable,
+                                            "Whether to call the credential providers found on the system to receive the credentials for the NuGet feed. See NuGet documentation for more info on NuGet Credential Providers: https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-exe-credential-providers."),
+                                        source.EnableCredentialProvider);
+                                    if (enableCredentialProvider != source.EnableCredentialProvider)
+                                    {
+                                        source.EnableCredentialProvider = enableCredentialProvider;
+                                        preferencesChangedThisFrame = true;
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
fixes #693 by allowing to disable credential providers + only log the error instead of failing the restore