### PR TITLE
Always enable FixRoslynAnalyzerImportSettings in CLI

### DIFF
--- a/src/NuGetForUnity.Cli/Program.cs
+++ b/src/NuGetForUnity.Cli/Program.cs
@@ -67,7 +67,7 @@ namespace NuGetForUnity.Cli
         }
 
         /// <summary>
-        ///     In Unity 2021 the errors that RoslynAnalyzer DLL's can't be imported because it has multiple files with the same name are blocking
+        ///     In Unity the errors that RoslynAnalyzer DLL's can't be imported because it has multiple files with the same name are blocking
         ///     even before our AssetPostprocessor can change the import settings so Unity knows that the DLL is a RoslynAnalyzer.
         ///     To bypass this error we generate the .dll.meta files with the RoslynAnalyzer label and the disable for platform configuration.
         ///     A alternative could be to delete the duplicate .resources.dll files when restoring,
@@ -75,12 +75,6 @@ namespace NuGetForUnity.Cli
         /// </summary>
         private static void FixRoslynAnalyzerImportSettings()
         {
-            if (int.Parse(Application.unityVersion.Split('.').First()) > 2021)
-            {
-                // in unity 2022 our AssetPostprocessor is handled before we get the errors for the RoslynAnalyzer DLL's
-                return;
-            }
-
             if (!Directory.Exists(ConfigurationManager.NugetConfigFile.RepositoryPath))
             {
                 return;


### PR DESCRIPTION
Always enable FixRoslynAnalyzerImportSettings to fix issue when our AssetPostprocessor isn't run early enough. Shouldn't be a issue as AssetPostprocessor will still run and sets the correct configuration.

should resolve the issue #637