### PR TITLE
Support for nuget package with multiple Roslyn version analyzers in CLI

### DIFF
--- a/src/NuGetForUnity.Cli/Program.cs
+++ b/src/NuGetForUnity.Cli/Program.cs
@@ -98,7 +98,12 @@ namespace NuGetForUnity.Cli
                         continue;
                     }
 
-                    if (!AnalyzerHelper.ShouldEnableRoslynAnalyzer(analyzerDllPath))
+                    // In Unity 2021 the errors that RoslynAnalyzer DLL's can't be imported because it has multiple files with the same name are blocking
+                    // even before our AssetPostprocessor can change the import settings so Unity knows that the DLL is a RoslynAnalyzer.
+                    // To bypass this error we generate the .dll.meta files with the RoslynAnalyzer label and the disable for platform configuration.
+                    // A alternative could be to delete the duplicate .resources.dll files when restoring,
+                    // but this would require to decide which user language to keep.
+                    if (int.Parse(Application.unityVersion.Split('.').First()) > 2021 && !AnalyzerHelper.ShouldEnableRoslynAnalyzer(analyzerDllPath))
                     {
                         continue;
                     }

--- a/src/NuGetForUnity.Cli/Program.cs
+++ b/src/NuGetForUnity.Cli/Program.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text;
 using NugetForUnity;
 using NugetForUnity.Configuration;
+using NugetForUnity.Helper;
 using UnityEngine;
 
 namespace NuGetForUnity.Cli
@@ -93,6 +94,11 @@ namespace NuGetForUnity.Cli
                 {
                     var analyzerDllMetaPath = $"{analyzerDllPath}.meta";
                     if (File.Exists(analyzerDllMetaPath))
+                    {
+                        continue;
+                    }
+
+                    if (!AnalyzerHelper.ShouldEnableRoslynAnalyzer(analyzerDllPath))
                     {
                         continue;
                     }

--- a/src/NuGetForUnity.Cli/Program.cs
+++ b/src/NuGetForUnity.Cli/Program.cs
@@ -98,15 +98,7 @@ namespace NuGetForUnity.Cli
                         continue;
                     }
 
-                    // In Unity 2021 the errors that RoslynAnalyzer DLL's can't be imported because it has multiple files with the same name are blocking
-                    // even before our AssetPostprocessor can change the import settings so Unity knows that the DLL is a RoslynAnalyzer.
-                    // To bypass this error we generate the .dll.meta files with the RoslynAnalyzer label and the disable for platform configuration.
-                    // A alternative could be to delete the duplicate .resources.dll files when restoring,
-                    // but this would require to decide which user language to keep.
-                    if (int.Parse(Application.unityVersion.Split('.').First()) > 2021 && !AnalyzerHelper.ShouldEnableRoslynAnalyzer(analyzerDllPath))
-                    {
-                        continue;
-                    }
+                    var isSupportedRoslynAnalyzer = AnalyzerHelper.ShouldEnableRoslynAnalyzer(analyzerDllPath);
 
                     utf8NoBom ??= new UTF8Encoding(false);
                     File.WriteAllText(

--- a/src/NuGetForUnity.Cli/Program.cs
+++ b/src/NuGetForUnity.Cli/Program.cs
@@ -101,17 +101,17 @@ namespace NuGetForUnity.Cli
                     var isSupportedRoslynAnalyzer = AnalyzerHelper.ShouldEnableRoslynAnalyzer(analyzerDllPath);
                     var labelsForAsset = isSupportedRoslynAnalyzer ?
                         """
-
+                        labels:
                         - RoslynAnalyzer
                         """ :
-                        "[]";
+                        "labels: []";
                     utf8NoBom ??= new UTF8Encoding(false);
                     File.WriteAllText(
                         analyzerDllMetaPath,
                         $"""
                          fileFormatVersion: 2
                          guid: {Guid.NewGuid():N}
-                         labels: {isSupportedRoslynAnalyzer}
+                         {labelsForAsset}
                          PluginImporter:
                            platformData:
                            - first:

--- a/src/NuGetForUnity.Cli/Program.cs
+++ b/src/NuGetForUnity.Cli/Program.cs
@@ -99,15 +99,19 @@ namespace NuGetForUnity.Cli
                     }
 
                     var isSupportedRoslynAnalyzer = AnalyzerHelper.ShouldEnableRoslynAnalyzer(analyzerDllPath);
+                    var labelsForAsset = isSupportedRoslynAnalyzer ?
+                        """
 
+                        - RoslynAnalyzer
+                        """ :
+                        "[]";
                     utf8NoBom ??= new UTF8Encoding(false);
                     File.WriteAllText(
                         analyzerDllMetaPath,
                         $"""
                          fileFormatVersion: 2
                          guid: {Guid.NewGuid():N}
-                         labels:
-                         - RoslynAnalyzer
+                         labels: {isSupportedRoslynAnalyzer}
                          PluginImporter:
                            platformData:
                            - first:

--- a/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
@@ -62,7 +62,7 @@ namespace NugetForUnity.Helper
                     var maxMatchingVersion = allEnabledRoslynVersions.Max();
                     if (!allEnabledRoslynVersions.Contains(assetRoslynVersion) || assetRoslynVersion < maxMatchingVersion)
                     {
-                        enableRoslynAnalyzer = false;
+                        return false;
                     }
                 }
             }

--- a/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
@@ -33,7 +33,6 @@ namespace NugetForUnity.Helper
         /// <returns>True if the label should be added, false otherwise.</returns>
         public static bool ShouldEnableRoslynAnalyzer(string path)
         {
-            var enableRoslynAnalyzer = true;
 
             // The nuget package can contain analyzers for multiple Roslyn versions.
             // In that case, for the same package, the most recent version must be chosen out of those available for the current Unity version.

--- a/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+using NugetForUnity.Models;
+
+namespace NugetForUnity.Helper
+{
+    /// <summary>
+    ///     Helper class for analyzers.
+    /// </summary>
+    internal static class AnalyzerHelper
+    {
+        /// <summary>
+        ///     Folder used to store Roslyn-Analyzers inside NuGet packages.
+        /// </summary>
+        private const string AnalyzersFolderName = "analyzers";
+
+        /// <summary>
+        ///     Name of the root folder containing dotnet analyzers.
+        /// </summary>
+        private static readonly string AnalyzersRoslynVersionsFolderName = Path.Combine(AnalyzersFolderName, "dotnet");
+
+        /// <summary>
+        ///     Prefix for the path of dll's of roslyn analyzers.
+        /// </summary>
+        private static readonly string AnalyzersRoslynVersionSubFolderPrefix = Path.Combine(AnalyzersRoslynVersionsFolderName, "roslyn");
+
+        /// <summary>
+        ///     Determine if "RoslynAnalyzer" label should be added to an analyzer
+        /// </summary>
+        /// <param name="path">The path to the analyzer</param>
+        /// <returns>True if the label should be added, false otherwise.</returns>
+        public static bool ShouldEnableRoslynAnalyzer(string path)
+        {
+            var enableRoslynAnalyzer = true;
+
+            // The nuget package can contain analyzers for multiple Roslyn versions.
+            // In that case, for the same package, the most recent version must be chosen out of those available for the current Unity version.
+            var assetPath = Path.GetFullPath(path);
+            var assetRoslynVersion = GetRoslynVersionNumberFromAnalyzerPath(assetPath);
+            if (assetRoslynVersion != null)
+            {
+                var maxSupportedRoslynVersion = GetMaxSupportedRoslynVersion();
+                if (maxSupportedRoslynVersion == null)
+                {
+                    // the current unity version doesn't support roslyn analyzers
+                    enableRoslynAnalyzer = false;
+                }
+                else
+                {
+                    var versionPrefixIndex = assetPath.IndexOf(AnalyzersRoslynVersionsFolderName, StringComparison.Ordinal);
+                    var analyzerVersionsRootDirectoryPath = Path.Combine(
+                        assetPath.Substring(0, versionPrefixIndex),
+                        AnalyzersRoslynVersionsFolderName);
+                    var analyzersFolders = Directory.EnumerateDirectories(analyzerVersionsRootDirectoryPath);
+                    var allEnabledRoslynVersions = analyzersFolders.Select(GetRoslynVersionNumberFromAnalyzerPath)
+                        .Where(version => version != null && version.CompareTo(maxSupportedRoslynVersion) <= 0)
+                        .ToArray();
+
+                    // If most recent valid analyzers exist elsewhere, don't add label `RoslynAnalyzer`
+                    var maxMatchingVersion = allEnabledRoslynVersions.Max();
+                    if (!allEnabledRoslynVersions.Contains(assetRoslynVersion) || assetRoslynVersion < maxMatchingVersion)
+                    {
+                        enableRoslynAnalyzer = false;
+                    }
+                }
+            }
+
+            return enableRoslynAnalyzer;
+        }
+
+        [CanBeNull]
+        private static NugetPackageVersion GetRoslynVersionNumberFromAnalyzerPath(string analyzerAssetPath)
+        {
+            var versionPrefixStartIndex = analyzerAssetPath.IndexOf(AnalyzersRoslynVersionSubFolderPrefix, StringComparison.Ordinal);
+            if (versionPrefixStartIndex < 0)
+            {
+                return null;
+            }
+
+            var versionStartIndex = versionPrefixStartIndex + AnalyzersRoslynVersionSubFolderPrefix.Length;
+            var separatorIndex = analyzerAssetPath.IndexOf(Path.DirectorySeparatorChar, versionStartIndex);
+            var versionLength = separatorIndex >= 0 ? separatorIndex - versionStartIndex : analyzerAssetPath.Length - versionStartIndex;
+            var versionString = analyzerAssetPath.Substring(versionStartIndex, versionLength);
+            return string.IsNullOrEmpty(versionString) ? null : new NugetPackageVersion(versionString);
+        }
+
+        [CanBeNull]
+        private static NugetPackageVersion GetMaxSupportedRoslynVersion()
+        {
+            var unityVersion = UnityVersion.Current;
+            if (unityVersion >= new UnityVersion(2022, 3, 12, 'f', 1))
+            {
+                return new NugetPackageVersion("4.3.0");
+            }
+
+            if (unityVersion >= new UnityVersion(2022, 2, 1, 'f', 1))
+            {
+                return new NugetPackageVersion("4.1.0");
+            }
+
+            if (unityVersion >= new UnityVersion(2021, 2, 1, 'f', 1))
+            {
+                return new NugetPackageVersion("3.8.0");
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
@@ -67,7 +67,7 @@ namespace NugetForUnity.Helper
                 }
             }
 
-            return enableRoslynAnalyzer;
+            return true;
         }
 
         [CanBeNull]

--- a/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
@@ -45,7 +45,7 @@ namespace NugetForUnity.Helper
                 if (maxSupportedRoslynVersion == null)
                 {
                     // the current unity version doesn't support roslyn analyzers
-                    enableRoslynAnalyzer = false;
+                    return false;
                 }
                 else
                 {

--- a/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
+++ b/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs
@@ -33,7 +33,6 @@ namespace NugetForUnity.Helper
         /// <returns>True if the label should be added, false otherwise.</returns>
         public static bool ShouldEnableRoslynAnalyzer(string path)
         {
-
             // The nuget package can contain analyzers for multiple Roslyn versions.
             // In that case, for the same package, the most recent version must be chosen out of those available for the current Unity version.
             var assetPath = Path.GetFullPath(path);
@@ -46,23 +45,19 @@ namespace NugetForUnity.Helper
                     // the current unity version doesn't support roslyn analyzers
                     return false;
                 }
-                else
-                {
-                    var versionPrefixIndex = assetPath.IndexOf(AnalyzersRoslynVersionsFolderName, StringComparison.Ordinal);
-                    var analyzerVersionsRootDirectoryPath = Path.Combine(
-                        assetPath.Substring(0, versionPrefixIndex),
-                        AnalyzersRoslynVersionsFolderName);
-                    var analyzersFolders = Directory.EnumerateDirectories(analyzerVersionsRootDirectoryPath);
-                    var allEnabledRoslynVersions = analyzersFolders.Select(GetRoslynVersionNumberFromAnalyzerPath)
-                        .Where(version => version != null && version.CompareTo(maxSupportedRoslynVersion) <= 0)
-                        .ToArray();
 
-                    // If most recent valid analyzers exist elsewhere, don't add label `RoslynAnalyzer`
-                    var maxMatchingVersion = allEnabledRoslynVersions.Max();
-                    if (!allEnabledRoslynVersions.Contains(assetRoslynVersion) || assetRoslynVersion < maxMatchingVersion)
-                    {
-                        return false;
-                    }
+                var versionPrefixIndex = assetPath.IndexOf(AnalyzersRoslynVersionsFolderName, StringComparison.Ordinal);
+                var analyzerVersionsRootDirectoryPath = Path.Combine(assetPath.Substring(0, versionPrefixIndex), AnalyzersRoslynVersionsFolderName);
+                var analyzersFolders = Directory.EnumerateDirectories(analyzerVersionsRootDirectoryPath);
+                var allEnabledRoslynVersions = analyzersFolders.Select(GetRoslynVersionNumberFromAnalyzerPath)
+                    .Where(version => version != null && version.CompareTo(maxSupportedRoslynVersion) <= 0)
+                    .ToArray();
+
+                // If most recent valid analyzers exist elsewhere, don't add label `RoslynAnalyzer`
+                var maxMatchingVersion = allEnabledRoslynVersions.Max();
+                if (!allEnabledRoslynVersions.Contains(assetRoslynVersion) || assetRoslynVersion < maxMatchingVersion)
+                {
+                    return false;
                 }
             }
 

--- a/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs.meta
+++ b/src/NuGetForUnity/Editor/Helper/AnalyzerHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7abfc0bbece578541aa4b670879d6dc2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
+++ b/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using JetBrains.Annotations;
 using NugetForUnity.Configuration;
 using NugetForUnity.Helper;
-using NugetForUnity.Models;
 using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -279,16 +278,14 @@ namespace NugetForUnity
                 plugin.SetExcludeFromAnyPlatform(platform, false);
             }
 
-            bool enableRoslynAnalyzer = AnalyzerHelper.ShouldEnableRoslynAnalyzer(plugin.assetPath);
+            var enableRoslynAnalyzer = AnalyzerHelper.ShouldEnableRoslynAnalyzer(plugin.assetPath);
             if (enableRoslynAnalyzer)
             {
                 NugetLogger.LogVerbose("Configured asset '{0}' as a Roslyn-Analyzer.", plugin.assetPath);
                 return new[] { RoslynAnalyzerLabel, ProcessedLabel };
             }
-            else
-            {
-                return new[] { ProcessedLabel };
-            }
+
+            return new[] { ProcessedLabel };
         }
 
         private static string[] ModifyImportSettingsOfGeneralPlugin([NotNull] PackageConfig packageConfig, [NotNull] PluginImporter plugin)


### PR DESCRIPTION
Reuse the logic implemented in #616 to handle nuget package with multiple Roslyn version analyzers in CLI.

Try to fix #704.