### PR TITLE
Sort pageitems before searching for correct package version (#709)

### DIFF
--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -488,6 +488,8 @@ namespace NugetForUnity.PackageSource
                 pageItem.items = await GetRegistrationPageLeafItems(packageSource, pageItem, cancellationToken).ConfigureAwait(false);
             }
 
+            pageItem.items = pageItem.items.OrderBy(leaf => new NugetPackageVersion(leaf.CatalogEntry.version)).ToList();
+
             var leafItem = getLatestVersion ?
                 pageItem.items.OrderByDescending(registrationLeaf => new NugetPackageVersion(registrationLeaf.CatalogEntry.version))
                     .FirstOrDefault() :

--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -492,8 +492,7 @@ namespace NugetForUnity.PackageSource
                 pageItem.items.OrderByDescending(registrationLeaf => new NugetPackageVersion(registrationLeaf.CatalogEntry.version))
                     .FirstOrDefault() :
                 pageItem.items.OrderBy(leaf => new NugetPackageVersion(leaf.CatalogEntry.version))
-                    .ToList()
-                    .Find(leaf => package.PackageVersion.InRange(new NugetPackageVersion(leaf.CatalogEntry.version)));
+                    .FirstOrDefault(leaf => package.PackageVersion.InRange(new NugetPackageVersion(leaf.CatalogEntry.version)));
             if (leafItem is null)
             {
                 Debug.LogError(

--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -488,12 +488,12 @@ namespace NugetForUnity.PackageSource
                 pageItem.items = await GetRegistrationPageLeafItems(packageSource, pageItem, cancellationToken).ConfigureAwait(false);
             }
 
-            pageItem.items = pageItem.items.OrderBy(leaf => new NugetPackageVersion(leaf.CatalogEntry.version)).ToList();
-
             var leafItem = getLatestVersion ?
                 pageItem.items.OrderByDescending(registrationLeaf => new NugetPackageVersion(registrationLeaf.CatalogEntry.version))
                     .FirstOrDefault() :
-                pageItem.items.Find(leaf => package.PackageVersion.InRange(new NugetPackageVersion(leaf.CatalogEntry.version)));
+                pageItem.items.OrderBy(leaf => new NugetPackageVersion(leaf.CatalogEntry.version))
+                    .ToList()
+                    .Find(leaf => package.PackageVersion.InRange(new NugetPackageVersion(leaf.CatalogEntry.version)));
             if (leafItem is null)
             {
                 Debug.LogError(

--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -473,7 +473,7 @@ namespace NugetForUnity.PackageSource
 
             var getLatestVersion = string.IsNullOrEmpty(package.Version);
             var pageItem = getLatestVersion ?
-                registrationItems.OrderByDescending(registrationItem => new NugetPackageVersion(registrationItem.lower)).First() :
+                registrationItems.OrderByDescending(registrationItem => new NugetPackageVersion(registrationItem.lower)).FirstOrDefault() :
                 registrationItems.Find(
                     registrationItem =>
                         new NugetPackageVersion($"[{registrationItem.lower},{registrationItem.upper}]").InRange(package.PackageVersion));


### PR DESCRIPTION
Attempt to fix issue where some nuget packages would forcibly update themselves to a higher version when performing a restore on the command line. #709 