### PR TITLE
Fix update for combined V3 package source

### DIFF
--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -82,7 +82,9 @@ namespace NugetForUnity.PackageSource
 
             apiIndexJsonUrl = new Uri(url);
 
+#pragma warning disable CA2000 // Dispose objects before losing scope: Ownership is transferred to httpClient
             var handler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
+#pragma warning restore CA2000 // Dispose objects before losing scope
             if (Application.platform == RuntimePlatform.WindowsEditor)
             {
                 // On Windows, Mono HttpClient does not automatically pick up proxy settings.
@@ -218,7 +220,7 @@ namespace NugetForUnity.PackageSource
 
                 var version = package.Version.ToLowerInvariant();
                 var id = package.Id.ToLowerInvariant();
-                downloadUrl = string.Format(packageDownloadUrlTemplate, id, version);
+                downloadUrl = string.Format(CultureInfo.InvariantCulture, packageDownloadUrlTemplate, id, version);
             }
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, downloadUrl))
@@ -521,6 +523,7 @@ namespace NugetForUnity.PackageSource
                        $"missing 'items' property inside page request for URL: {itemAtId}, response:\n{registrationPageString}");
         }
 
+        [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "We intentionally use lower case.")]
         private async Task<List<RegistrationPageObject>> GetRegistrationPageItemsAsync(
             NugetPackageSourceV3 packageSource,
             INugetPackageIdentifier package,

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
@@ -267,7 +267,7 @@ namespace NugetForUnity.PackageSource
                         var fetchedPackages = await Task.WhenAll(
                                 packagesToFetch.Select(package => ApiClient.GetPackageWithAllVersionsAsync(this, package, CancellationToken.None)))
                             .ConfigureAwait(false);
-                        return fetchedPackages.ToList<INugetPackage>();
+                        return fetchedPackages.Where(fetchedPackage => !(fetchedPackage is null)).ToList<INugetPackage>();
                     })
                 .GetAwaiter()
                 .GetResult();


### PR DESCRIPTION
fix update when using multiple V3 sources (there could be a 'null' package added to the list if the package was not available on the package source)

fixes: #714