### PR TITLE
Sped up the refresh of package updates

### DIFF
--- a/src/NuGetForUnity/Editor/Configuration/ConfigurationManager.cs
+++ b/src/NuGetForUnity/Editor/Configuration/ConfigurationManager.cs
@@ -247,17 +247,7 @@ namespace NugetForUnity.Configuration
             string versionConstraints = "",
             CancellationToken token = default)
         {
-            // Fetching package updates often requires a lot of requests so we increase the limit to speed them up.
-            var oldConnectionLimit = ServicePointManager.DefaultConnectionLimit;
-            try
-            {
-                ServicePointManager.DefaultConnectionLimit = 20;
-                return ActivePackageSource.GetUpdates(packagesToUpdate, includePrerelease, targetFrameworks, versionConstraints, token);
-            }
-            finally
-            {
-                ServicePointManager.DefaultConnectionLimit = oldConnectionLimit;
-            }
+            return ActivePackageSource.GetUpdates(packagesToUpdate, includePrerelease, targetFrameworks, versionConstraints, token);
         }
 
         /// <inheritdoc cref="INugetPackageSource.GetSpecificPackage(INugetPackageIdentifier)" />

--- a/src/NuGetForUnity/Editor/PackageSource/INugetPackageSource.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/INugetPackageSource.cs
@@ -103,6 +103,7 @@ namespace NugetForUnity.PackageSource
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
         /// <param name="targetFrameworks">The specific frameworks to target?.</param>
         /// <param name="versionConstraints">The version constraints?.</param>
+        /// <param name="token">The cancellation token?.</param>
         /// <returns>A list of all updates available.</returns>
         [NotNull]
         [ItemNotNull]
@@ -110,7 +111,8 @@ namespace NugetForUnity.PackageSource
             [NotNull] [ItemNotNull] IEnumerable<INugetPackage> packages,
             bool includePrerelease = false,
             string targetFrameworks = "",
-            string versionConstraints = "");
+            string versionConstraints = "",
+            CancellationToken token = default);
 
         /// <summary>
         ///     Gets a list of NugetPackages from this package source.

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceCombined.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceCombined.cs
@@ -221,7 +221,7 @@ namespace NugetForUnity.PackageSource
                 return packageSources.First(source => source.IsEnabled).GetUpdates(packages, includePrerelease, targetFrameworks, versionConstraints, token);
             }
 
-            return packageSources.Where(source => source.IsEnabled)
+            return packageSources.AsParallel().Where(source => source.IsEnabled)
                 .SelectMany(source => source.GetUpdates(packages, includePrerelease, targetFrameworks, versionConstraints, token))
                 .Distinct()
                 .ToList();

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceCombined.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceCombined.cs
@@ -206,7 +206,8 @@ namespace NugetForUnity.PackageSource
             IEnumerable<INugetPackage> packages,
             bool includePrerelease = false,
             string targetFrameworks = "",
-            string versionConstraints = "")
+            string versionConstraints = "",
+            CancellationToken token = default)
         {
             var activeSourcesCount = packageSources.Count(source => source.IsEnabled);
             if (activeSourcesCount == 0)
@@ -217,11 +218,11 @@ namespace NugetForUnity.PackageSource
 
             if (activeSourcesCount == 1)
             {
-                return packageSources.First(source => source.IsEnabled).GetUpdates(packages, includePrerelease, targetFrameworks, versionConstraints);
+                return packageSources.First(source => source.IsEnabled).GetUpdates(packages, includePrerelease, targetFrameworks, versionConstraints, token);
             }
 
             return packageSources.Where(source => source.IsEnabled)
-                .SelectMany(source => source.GetUpdates(packages, includePrerelease, targetFrameworks, versionConstraints))
+                .SelectMany(source => source.GetUpdates(packages, includePrerelease, targetFrameworks, versionConstraints, token))
                 .Distinct()
                 .ToList();
         }

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceLocal.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceLocal.cs
@@ -190,9 +190,10 @@ namespace NugetForUnity.PackageSource
             IEnumerable<INugetPackage> packages,
             bool includePrerelease = false,
             string targetFrameworks = "",
-            string versionConstraints = "")
+            string versionConstraints = "",
+            CancellationToken token = default)
         {
-            return GetLocalUpdates(packages, includePrerelease);
+            return GetLocalUpdates(packages, includePrerelease, token);
         }
 
         /// <inheritdoc />
@@ -329,14 +330,20 @@ namespace NugetForUnity.PackageSource
         /// </summary>
         /// <param name="packages">The list of packages to use to find updates.</param>
         /// <param name="includePrerelease">True to include prerelease packages (alpha, beta, etc).</param>
+        /// <param name="token"></param>
         /// <returns>A list of all updates / downgrades available.</returns>
         [NotNull]
         [ItemNotNull]
-        private List<INugetPackage> GetLocalUpdates([NotNull] [ItemNotNull] IEnumerable<INugetPackage> packages, bool includePrerelease = false)
+        private List<INugetPackage> GetLocalUpdates(
+            [NotNull] [ItemNotNull] IEnumerable<INugetPackage> packages,
+            bool includePrerelease = false,
+            CancellationToken token = default)
         {
             var updates = new List<INugetPackage>();
             foreach (var packageToSearch in packages)
             {
+                token.ThrowIfCancellationRequested();
+
                 var availablePackages = GetLocalPackages($"{packageToSearch.Id}*", false, includePrerelease);
                 foreach (var availablePackage in availablePackages)
                 {

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV2.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV2.cs
@@ -279,7 +279,8 @@ namespace NugetForUnity.PackageSource
             IEnumerable<INugetPackage> packages,
             bool includePrerelease = false,
             string targetFrameworks = "",
-            string versionConstraints = "")
+            string versionConstraints = "",
+            CancellationToken token = default)
         {
             var updates = new List<INugetPackage>();
             var packagesCollection = packages as ICollection<INugetPackage> ?? packages.ToList();
@@ -287,6 +288,8 @@ namespace NugetForUnity.PackageSource
             // check for updates in groups of 10 instead of all of them, since that causes servers to throw errors for queries that are too long
             for (var i = 0; i < packagesCollection.Count; i += 10)
             {
+                token.ThrowIfCancellationRequested();
+
                 var packageGroup = packagesCollection.Skip(i).Take(10);
 
                 var packageIds = string.Empty;

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
@@ -243,21 +243,17 @@ namespace NugetForUnity.PackageSource
                                     searchQueryBuilder.Append($"packageid:{packagesToFetch[i].Id}");
                                 }
 
-                                async Task<List<INugetPackage>> SearchPackageAsync() =>
-                                    await ApiClient.SearchPackageAsync(
+                                fetchTasks.Add(ApiClient.SearchPackageAsync(
                                             this,
                                             searchQueryBuilder.ToString(),
                                             0,
                                             0,
                                             includePrerelease,
-                                            token)
-                                        .ConfigureAwait(false);
-
-                                fetchTasks.Add(SearchPackageAsync());
+                                            token));
                             }
 
                             var nestedUpdates = await Task.WhenAll(fetchTasks).ConfigureAwait(false);
-                            var updates = nestedUpdates.SelectMany(r => r).ToList();
+                            var updates = nestedUpdates.SelectMany(nestedPackages => nestedPackages).ToList();
 
                             if (updates.Count > packagesToFetch.Count)
                             {

--- a/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetPackageSourceV3.cs
@@ -227,49 +227,56 @@ namespace NugetForUnity.PackageSource
             var packagesFromServer = Task.Run(
                     async () =>
                     {
-                        if (SupportsPackageIdSearchFilter)
+                        try
                         {
-                            var fetchTasks = new List<Task<List<INugetPackage>>>();
-                            for (var i = 0; i < packagesToFetch.Count;)
+                            if (SupportsPackageIdSearchFilter)
                             {
-                                var searchQueryBuilder = new StringBuilder();
-                                for (var inner = 0; inner < UpdateSearchBatchSize && i < packagesToFetch.Count; inner++, i++)
+                                var fetchTasks = new List<Task<List<INugetPackage>>>();
+                                for (var i = 0; i < packagesToFetch.Count;)
                                 {
-                                    if (i > 0)
+                                    var searchQueryBuilder = new StringBuilder();
+                                    for (var inner = 0; inner < UpdateSearchBatchSize && i < packagesToFetch.Count; inner++, i++)
                                     {
-                                        searchQueryBuilder.Append(' ');
+                                        if (i > 0)
+                                        {
+                                            searchQueryBuilder.Append(' ');
+                                        }
+
+                                        searchQueryBuilder.Append($"packageid:{packagesToFetch[i].Id}");
                                     }
 
-                                    searchQueryBuilder.Append($"packageid:{packagesToFetch[i].Id}");
+                                    fetchTasks.Add(ApiClient.SearchPackageAsync(this, searchQueryBuilder.ToString(), 0, 0, includePrerelease, token));
                                 }
 
-                                fetchTasks.Add(ApiClient.SearchPackageAsync(
-                                            this,
-                                            searchQueryBuilder.ToString(),
-                                            0,
-                                            0,
-                                            includePrerelease,
-                                            token));
+                                var nestedUpdates = await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+                                var updates = nestedUpdates.SelectMany(nestedPackages => nestedPackages).ToList();
+
+                                if (updates.Count > packagesToFetch.Count)
+                                {
+                                    Debug.LogWarningFormat(
+                                        "Fetching updates using a filter with the format 'packageid:{{packageId}}' resulted in more packages as requested. This probably means that the syntax is not supported by the package source {0}. So consider switching to a different 'update search mechanism' by disabling the '{1}' setting for this package source.",
+                                        SavedPath,
+                                        nameof(SupportsPackageIdSearchFilter));
+                                }
+
+                                return updates;
                             }
 
-                            var nestedUpdates = await Task.WhenAll(fetchTasks).ConfigureAwait(false);
-                            var updates = nestedUpdates.SelectMany(nestedPackages => nestedPackages).ToList();
-
-                            if (updates.Count > packagesToFetch.Count)
-                            {
-                                Debug.LogWarningFormat(
-                                    "Fetching updates using a filter with the format 'packageid:{{packageId}}' resulted in more packages as requested. This probably means that the syntax is not supported by the package source {0}. So consider switching to a different 'update search mechanism' by disabling the '{1}' setting for this package source.",
-                                    SavedPath,
-                                    nameof(SupportsPackageIdSearchFilter));
-                            }
-
-                            return updates;
+                            var fetchedPackages = await Task.WhenAll(
+                                    packagesToFetch.Select(package =>
+                                        ApiClient.GetPackageWithAllVersionsAsync(this, package, CancellationToken.None)))
+                                .ConfigureAwait(false);
+                            return fetchedPackages.Where(fetchedPackage => !(fetchedPackage is null)).ToList<INugetPackage>();
                         }
-
-                        var fetchedPackages = await Task.WhenAll(
-                                packagesToFetch.Select(package => ApiClient.GetPackageWithAllVersionsAsync(this, package, CancellationToken.None)))
-                            .ConfigureAwait(false);
-                        return fetchedPackages.Where(fetchedPackage => !(fetchedPackage is null)).ToList<INugetPackage>();
+                        catch (OperationCanceledException)
+                        {
+                            return new List<INugetPackage>();
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.LogException(e);
+                            return new List<INugetPackage>();
+                        }
                     },
                     token)
                 .GetAwaiter()

--- a/src/NuGetForUnity/Editor/Ui/NugetWindow.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetWindow.cs
@@ -611,8 +611,8 @@ namespace NugetForUnity.Ui
             }
             else
             {
-                var msg = fetchingUpdates ? "Fetching package updates. Please wait..." : "There are no updates available!";
-                DrawNoDataAvailableInfo(msg);
+                var message = fetchingUpdates ? "Fetching package updates. Please wait..." : "There are no updates available!";
+                DrawNoDataAvailableInfo(message);
             }
 
             EditorGUILayout.EndVertical();

--- a/src/NuGetForUnity/Editor/Ui/NugetWindow.cs
+++ b/src/NuGetForUnity/Editor/Ui/NugetWindow.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using NugetForUnity.Configuration;
@@ -167,6 +168,16 @@ namespace NugetForUnity.Ui
         ///     The search term to search the update packages for.
         /// </summary>
         private string updatesSearchTerm;
+
+        /// <summary>
+        /// True while fetching updates is in progress since it is done in background.
+        /// </summary>
+        private bool fetchingUpdates;
+
+        /// <summary>
+        /// Used to cancel fetching updates if the window is closed.
+        /// </summary>
+        private CancellationTokenSource fetchUpdatesCancellationSource;
 
         /// <summary>
         ///     Gets the filtered list of package updates available.
@@ -389,6 +400,11 @@ namespace NugetForUnity.Ui
             UnityPathHelper.EnsurePackageInstallDirectoryIsSetup();
         }
 
+        private void OnDisable()
+        {
+            fetchUpdatesCancellationSource?.Cancel();
+        }
+
         /// <summary>
         ///     Filter not updatable / not downgradable packages based on showDowngrades.
         /// </summary>
@@ -455,7 +471,14 @@ namespace NugetForUnity.Ui
                     UpdateInstalledPackages();
 
                     EditorUtility.DisplayProgressBar("Opening NuGet", "Getting available updates...", 0.9f);
-                    UpdateUpdatePackages();
+                    if (forceFullRefresh)
+                    {
+                        UpdateUpdatePackages();
+                    }
+                    else
+                    {
+                        UpdateUpdatePackagesInBackground();
+                    }
 
                     versionDropdownDataPerPackage.Clear();
 
@@ -519,6 +542,40 @@ namespace NugetForUnity.Ui
             updatePackages = ConfigurationManager.GetUpdates(InstalledPackagesManager.InstalledPackages, showPrereleaseUpdates);
         }
 
+        /// <summary>
+        ///     Updates the list of update packages.
+        /// </summary>
+        private void UpdateUpdatePackagesInBackground()
+        {
+            fetchingUpdates = true;
+            fetchUpdatesCancellationSource = new CancellationTokenSource();
+            var token = fetchUpdatesCancellationSource.Token;
+            Task.Run(() =>
+            {
+                try
+                {
+                    updatePackages = ConfigurationManager.GetUpdates(
+                        InstalledPackagesManager.InstalledPackages,
+                        showPrereleaseUpdates,
+                        token: token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // ignore
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
+                finally
+                {
+                    EditorApplication.delayCall += Repaint;
+                    fetchingUpdates = false;
+                }
+            },
+            token);
+        }
+
         private void OnTabChanged()
         {
             openCloneWindows.Clear();
@@ -554,7 +611,8 @@ namespace NugetForUnity.Ui
             }
             else
             {
-                DrawNoDataAvailableInfo("There are no updates available!");
+                var msg = fetchingUpdates ? "Fetching package updates. Please wait..." : "There are no updates available!";
+                DrawNoDataAvailableInfo(msg);
             }
 
             EditorGUILayout.EndVertical();


### PR DESCRIPTION
We added additional Artifactory source that has a lot of packages with a lot of versions and opening Nuget window started taking 20s. I moved fetching updates when window is opened to a background thread so that window is opened much faster. I also sped up the fetching of package updates by using Task.WhenAll to fetch them all in parallel instead of one by one. In case window is closed while fetching is in progress CancellationToken is used to cancel it all.