### PR TITLE
Disable autoReferenced in NuGetForUnity.asmdef

### DIFF
--- a/src/NuGetForUnity/Editor/NuGetForUnity.asmdef
+++ b/src/NuGetForUnity/Editor/NuGetForUnity.asmdef
@@ -11,7 +11,7 @@
     "precompiledReferences": [
         "NuGetForUnity.PluginAPI.dll"
     ],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
This is a proposed workaround for IDE-side build problems caused by #672.

The `autoReferenced` setting causes the NuGetForUnity assembly to be added as a dependency to the Assembly-CSharp assembly, making it difficult to use certain IDE features (e.g., Rider's IL viewer, which requires the project to be built).

This change implies breaking backwards compatibility for users that rely on accessing the NuGetForUnity assembly from Assembly-CSharp and friends. I think it's a bit of an anti-pattern for an editor tool anyway, and extending NuGetForUnity can always be achieved via direct assembly references. 