### PR TITLE
Ability to set the DefineConstraints of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,16 @@ To disable the automatic referencing of assemblies of a NuGet package you can se
 </packages>
 ```
 
+## Define constraints
+To restrict when a NuGet package is referenced based on Scripting Define Symbols, you can set the `defineConstraints` attribute of a package inside the `packages.config`. All defines listed in `defineConstraints` must be present for the package assemblies to be referenced, just like in Unity’s `.asmdef` files. If the attribute is omitted, the package is always referenced.
+_Currently this setting is not available from UI._
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<packages>
+    <package id="Serilog" version="2.12.0" autoReferenced="false" defineConstraints="UNITY_EDITOR;DEVELOPMENT_BUILD" />
+</packages>
+```
+
 When this setting is set to `false` the assemblies of the NuGet package are only referenced by Unity projects that explicitly list them inside there `*.asmdef` file.
 
 # How do I create my own NuGet packages from within Unity?

--- a/src/NuGetForUnity/Editor/Configuration/PackageConfig.cs
+++ b/src/NuGetForUnity/Editor/Configuration/PackageConfig.cs
@@ -16,6 +16,8 @@ namespace NugetForUnity.Configuration
         /// </summary>
         public bool AutoReferenced { get; set; } = true;
 
+        public string DefineConstraints { get; set; } = string.Empty;
+
         /// <summary>
         ///     Gets or sets the configured target framework moniker that is used to install this NuGet package instead of
         ///     automatically determining the best matching target framework from the Unity settings ('Api Compatibility Level').

--- a/src/NuGetForUnity/Editor/Configuration/PackageConfig.cs
+++ b/src/NuGetForUnity/Editor/Configuration/PackageConfig.cs
@@ -16,6 +16,13 @@ namespace NugetForUnity.Configuration
         /// </summary>
         public bool AutoReferenced { get; set; } = true;
 
+        /// <summary>
+        ///     Gets or sets additional compile-time constraints associated with this package.
+        ///     This property contains a string representing extra compile-time constraints related to the package,
+        ///     such as conditional compilation symbols or conditions for applying the package. Multiple constraints
+        ///     can be combined using a delimiter (for example, a semicolon ';'); the exact delimiter and parsing
+        ///     rules are determined by the consumer of this property. An empty string means no constraints. The default value is an empty string.
+        /// </summary>
         public string DefineConstraints { get; set; } = string.Empty;
 
         /// <summary>

--- a/src/NuGetForUnity/Editor/Configuration/PackageConfig.cs
+++ b/src/NuGetForUnity/Editor/Configuration/PackageConfig.cs
@@ -20,8 +20,8 @@ namespace NugetForUnity.Configuration
         ///     Gets or sets additional compile-time constraints associated with this package.
         ///     This property contains a string representing extra compile-time constraints related to the package,
         ///     such as conditional compilation symbols or conditions for applying the package. Multiple constraints
-        ///     can be combined using a delimiter (for example, a semicolon ';'); the exact delimiter and parsing
-        ///     rules are determined by the consumer of this property. An empty string means no constraints. The default value is an empty string.
+        ///     can be combined using a delimiter (a semicolon ';').
+        ///     An empty string means no constraints. The default value is an empty string.
         /// </summary>
         public string DefineConstraints { get; set; } = string.Empty;
 

--- a/src/NuGetForUnity/Editor/Configuration/PackagesConfigFile.cs
+++ b/src/NuGetForUnity/Editor/Configuration/PackagesConfigFile.cs
@@ -22,6 +22,8 @@ namespace NugetForUnity.Configuration
 
         private const string AutoReferencedAttributeName = "autoReferenced";
 
+        private const string DefineConstraintsAttributeName = "defineConstraints";
+
         private const string TargetFrameworkAttributeName = "targetFramework";
 
         [CanBeNull]
@@ -73,6 +75,7 @@ namespace NugetForUnity.Configuration
                         packageElement.Attribute("manuallyInstalled")?.Value.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false,
                     AutoReferenced = (bool)(packageElement.Attributes(AutoReferencedAttributeName).FirstOrDefault() ??
                                             new XAttribute(AutoReferencedAttributeName, true)),
+                    DefineConstraints = packageElement.Attribute(DefineConstraintsAttributeName)?.Value ?? string.Empty,
                     TargetFramework = packageElement.Attribute(TargetFrameworkAttributeName)?.Value,
                 };
                 configFile.Packages.Add(package);
@@ -146,6 +149,11 @@ namespace NugetForUnity.Configuration
                 if (!package.AutoReferenced)
                 {
                     packageElement.Add(new XAttribute(AutoReferencedAttributeName, package.AutoReferenced));
+                }
+
+                if (!string.IsNullOrEmpty(package.DefineConstraints))
+                {
+                    packageElement.Add(new XAttribute(DefineConstraintsAttributeName, package.DefineConstraints));
                 }
 
                 if (!string.IsNullOrEmpty(package.TargetFramework))

--- a/src/NuGetForUnity/Editor/Configuration/PackagesConfigFile.cs
+++ b/src/NuGetForUnity/Editor/Configuration/PackagesConfigFile.cs
@@ -151,7 +151,7 @@ namespace NugetForUnity.Configuration
                     packageElement.Add(new XAttribute(AutoReferencedAttributeName, package.AutoReferenced));
                 }
 
-                if (!string.IsNullOrEmpty(package.DefineConstraints))
+                if (!string.IsNullOrWhiteSpace(package.DefineConstraints))
                 {
                     packageElement.Add(new XAttribute(DefineConstraintsAttributeName, package.DefineConstraints));
                 }

--- a/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
+++ b/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
@@ -294,7 +294,7 @@ namespace NugetForUnity
 
             if (!string.IsNullOrWhiteSpace(packageConfig.DefineConstraints))
             {
-                plugin.DefineConstraints = packageConfig.DefineConstraints.Split(";", StringSplitOptions.RemoveEmptyEntries);
+                plugin.DefineConstraints = packageConfig.DefineConstraints.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             }
 
             return new[] { ProcessedLabel };

--- a/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
+++ b/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
@@ -294,7 +294,7 @@ namespace NugetForUnity
 
             if (!string.IsNullOrWhiteSpace(packageConfig.DefineConstraints))
             {
-                plugin.DefineConstraints = packageConfig.DefineConstraints.Split(';', StringSplitOptions.RemoveEmptyEntries);
+                plugin.DefineConstraints = packageConfig.DefineConstraints.Split(";", StringSplitOptions.RemoveEmptyEntries);
             }
 
             return new[] { ProcessedLabel };

--- a/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
+++ b/src/NuGetForUnity/Editor/NugetAssetPostprocessor.cs
@@ -292,6 +292,11 @@ namespace NugetForUnity
         {
             PluginImporterIsExplicitlyReferencedProperty.SetValue(plugin, !packageConfig.AutoReferenced);
 
+            if (!string.IsNullOrWhiteSpace(packageConfig.DefineConstraints))
+            {
+                plugin.DefineConstraints = packageConfig.DefineConstraints.Split(';', StringSplitOptions.RemoveEmptyEntries);
+            }
+
             return new[] { ProcessedLabel };
         }
 


### PR DESCRIPTION
This is the implementation of feature #639 .

Enabling the `DefineConstraints` setting allows you to, for example, set restrictions on `UNITY_EDITOR` definitions for specific packages and exclude them from the build output.

This proves extremely useful within the Unity environment.

Refer to the existing implementation; #507 