### PR TITLE
Fix analyzer .meta file format in CLI restore (#737)

### DIFF
--- a/src/NuGetForUnity.Cli/Program.cs
+++ b/src/NuGetForUnity.Cli/Program.cs
@@ -113,6 +113,7 @@ namespace NuGetForUnity.Cli
                          guid: {Guid.NewGuid():N}
                          {labelsForAsset}
                          PluginImporter:
+                           serializedVersion: 2
                            platformData:
                            - first:
                                : Any


### PR DESCRIPTION
Add serializedVersion to analyzer .meta files in restoration. This fixes build failures where AssetPostprocessor doesn't work as expected. (#737)