### PR TITLE
Fixed nuget packages get lost with Unity 6

### DIFF
--- a/src/NuGetForUnity/Editor/OnLoadNugetPackageRestorer.cs
+++ b/src/NuGetForUnity/Editor/OnLoadNugetPackageRestorer.cs
@@ -15,10 +15,12 @@ namespace NugetForUnity
         /// </summary>
         static OnLoadNugetPackageRestorer()
         {
+    #if UNITY_6000_0_OR_NEWER
             if (AssetDatabase.IsAssetImportWorkerProcess())
             {
                 return;
             }
+    #endif
             
             if (SessionState.GetBool("NugetForUnity.FirstProjectOpen", false))
             {


### PR DESCRIPTION
In Unity 6 it can happen that multiple asset import worker processes get started at the same time then this will lead to undefined behavior because session data is new for each worker process, so it will execute the code in parallel multiple times.