### PR TITLE
Add osx runtime support for Universal Binary

### DIFF
--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -1103,6 +1103,7 @@ public class NuGetTests
     [TestCase("win-x86", BuildTarget.StandaloneWindows)]
     [TestCase("linux-x64", BuildTarget.StandaloneLinux64)]
     [TestCase("osx-x64", BuildTarget.StandaloneOSX)]
+    [TestCase("osx", BuildTarget.StandaloneOSX)]
     public void NativeSettingsTest(string runtime, BuildTarget buildTarget)
     {
         var nativeSettingsFilePath = Path.Combine(

--- a/src/NuGetForUnity/Editor/Configuration/NativeRuntimeSettings.cs
+++ b/src/NuGetForUnity/Editor/Configuration/NativeRuntimeSettings.cs
@@ -82,6 +82,7 @@ namespace NugetForUnity.Configuration
                     new NativeRuntimeAssetConfiguration("ios-arm64", "ARM64", null, null, BuildTarget.iOS),
                     new NativeRuntimeAssetConfiguration("osx-x64", "x86_64", null, "OSX", BuildTarget.StandaloneOSX),
                     new NativeRuntimeAssetConfiguration("osx-arm64", "ARM64", null, null, BuildTarget.StandaloneOSX),
+                    new NativeRuntimeAssetConfiguration("osx", "AnyCPU", "AnyCPU", "OSX", BuildTarget.StandaloneOSX),
                 },
             };
         }


### PR DESCRIPTION
## Summary
Add `osx` runtime entry to NativeRuntimeSettings defaults to support macOS Universal Binary (FAT) packages.

## Changes
- Add `osx` runtime configuration with AnyCPU settings for both runtime and editor
- Add test case for `osx` runtime in NativeSettingsTest

## Motivation
Some NuGet packages use the `osx` runtime identifier (without architecture suffix) for Universal Binary libraries that support both x64 and ARM64. For example:
- MongoDB.Libmongocrypt uses `runtimes/osx/native/` structure (see #655)

Currently, NuGetForUnity only has `osx-x64` and `osx-arm64` entries, so packages using the `osx` runtime identifier are not properly imported.

## Test Plan
- Added test case `[TestCase("osx", BuildTarget.StandaloneOSX)]` in NativeSettingsTest
- Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
