### PR TITLE
Skip MSBuild-only package files

### DIFF
--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -59,6 +59,13 @@ public class NuGetTests
         Assert.Pass();
     }
 
+    [TestCase("buildTransitive/config/analysislevel.globalconfig")]
+    [TestCase("rulesets/MicrosoftCodeAnalysisReleaseTrackingRulesEnabled.ruleset")]
+    public void SkipMsBuildOnlyFilesTest(string path)
+    {
+        Assert.IsTrue(PackageContentManager.ShouldSkipUnpackingOnPath(path, null));
+    }
+
     [Test]
     [Order(2)]
     public void InstallJsonTest([Values] InstallMode installMode)

--- a/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
+++ b/src/NuGetForUnity.Tests/Assets/Tests/Editor/NuGetTests.cs
@@ -66,6 +66,19 @@ public class NuGetTests
         Assert.IsTrue(PackageContentManager.ShouldSkipUnpackingOnPath(path, null));
     }
 
+    [TestCase("analyzers/roslyn4.3/cs/MessagePack.Analyzers.CodeFixes.dll")]
+    [TestCase("analyzers/dotnet/cs/Microsoft.CodeAnalysis.Analyzers.dll")]
+    public void SkipUnityIncompatibleAnalyzerTest(string path)
+    {
+        Assert.IsTrue(PackageContentManager.ShouldSkipUnpackingOnPath(path, null));
+    }
+
+    [Test]
+    public void KeepMessagePackSourceGeneratorTest()
+    {
+        Assert.IsFalse(PackageContentManager.ShouldSkipUnpackingOnPath("analyzers/roslyn4.3/cs/MessagePack.SourceGenerator.dll", null));
+    }
+
     [Test]
     [Order(2)]
     public void InstallJsonTest([Values] InstallMode installMode)

--- a/src/NuGetForUnity/Editor/PackageContentManager.cs
+++ b/src/NuGetForUnity/Editor/PackageContentManager.cs
@@ -156,6 +156,13 @@ namespace NugetForUnity
                 return true;
             }
 
+            if ((path.StartsWith("analyzers/", StringComparison.Ordinal) || path.Contains("/analyzers/")) &&
+                (path.EndsWith(".CodeFixes.dll", StringComparison.Ordinal) ||
+                 Path.GetFileName(path).StartsWith("Microsoft.CodeAnalysis.", StringComparison.Ordinal)))
+            {
+                return true;
+            }
+
             // For now, skip src. We may use it later...
             if (path.StartsWith("src/", StringComparison.Ordinal) || path.Contains("/src/"))
             {

--- a/src/NuGetForUnity/Editor/PackageContentManager.cs
+++ b/src/NuGetForUnity/Editor/PackageContentManager.cs
@@ -146,6 +146,16 @@ namespace NugetForUnity
                 return true;
             }
 
+            if (path.StartsWith("buildTransitive/", StringComparison.Ordinal) || path.Contains("/buildTransitive/"))
+            {
+                return true;
+            }
+
+            if (path.StartsWith("rulesets/", StringComparison.Ordinal) || path.Contains("/rulesets/"))
+            {
+                return true;
+            }
+
             // For now, skip src. We may use it later...
             if (path.StartsWith("src/", StringComparison.Ordinal) || path.Contains("/src/"))
             {


### PR DESCRIPTION
 Fixes #707.

NuGet packages can contain `buildTransitive` and `rulesets` directories for MSBuild.

Unity imports extracted `.globalconfig` and `.ruleset` files as analyzer configuration files. When a package contains multiple such files, Unity logs repeated “already contains” warnings during project import.

Skip these MSBuild-only directories during package extraction, consistent with the existing `build` directory handling. Analyzer assemblies are still extracted.

References:
  - https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Compilation.ScriptCompilerOptions.AnalyzerConfigPath.html

Add coverage for both directory paths.